### PR TITLE
Nbp outputs

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -510,7 +510,7 @@ contains
     ! !ARGUMENTS:
     type (ed_site_type), intent(inout) :: currentSite
     type (bc_in_type), intent(in)      :: bc_in
-    type (bc_out_type), intent(in)     :: bc_out
+    type (bc_out_type), intent(inout)  :: bc_out
     !
     ! !LOCAL VARIABLES:
     type (fates_patch_type) , pointer :: newPatch
@@ -755,7 +755,9 @@ contains
 
                             call CopyPatchMeansTimers(currentPatch, newPatch)
 
-                            call TransLitterNewPatch( currentSite, currentPatch, newPatch, patch_site_areadis, i_disturbance_type)
+
+                            call TransLitterNewPatch( currentSite, currentPatch, newPatch, patch_site_areadis, bc_out)
+
 
                             ! Transfer in litter fluxes from plants in various contexts of death and destruction
                             select case(i_disturbance_type)
@@ -1071,7 +1073,7 @@ contains
                                           leaf_burn_frac * leaf_m * nc%n
 
                                      bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + &
-                                          leaf_burn_frac * leaf_m * nc%n
+                                          leaf_burn_frac * leaf_m * nc%n * ha_per_m2 * days_per_sec
                                   end do
 
                                   ! Here the mass is removed from the plant
@@ -1420,7 +1422,7 @@ contains
 
                          allocate(temp_patch)
 
-                         call split_patch(currentSite, currentPatch, temp_patch, fraction_to_keep, newp_area)
+                         call split_patch(currentSite, currentPatch, temp_patch, fraction_to_keep, newp_area, bc_out)
                          !
                          temp_patch%nocomp_pft_label = 0
 
@@ -1523,7 +1525,7 @@ contains
                                ! split buffer patch in two, keeping the smaller buffer patch to put into new patches
                                allocate(temp_patch)
 
-                               call split_patch(currentSite, buffer_patch, temp_patch, fraction_to_keep, newp_area)
+                               call split_patch(currentSite, buffer_patch, temp_patch, fraction_to_keep, newp_area, bc_out)
 
                                ! give the new patch the intended nocomp PFT label
                                temp_patch%nocomp_pft_label = i_pft
@@ -1632,7 +1634,7 @@ contains
 
   ! -----------------------------------------------------------------------------------------
 
-  subroutine split_patch(currentSite, currentPatch, new_patch, fraction_to_keep, area_to_remove)
+  subroutine split_patch(currentSite, currentPatch, new_patch, fraction_to_keep, area_to_remove, bc_out)
     !
     ! !DESCRIPTION:
     !  Split a patch into two patches that are identical except in their areas
@@ -1643,6 +1645,7 @@ contains
     type(fates_patch_type) , intent(inout), pointer :: new_patch         ! New Patch
     real(r8), intent(in)                            :: fraction_to_keep  ! fraction of currentPatch to keep, the rest goes to newpatch
     real(r8), intent(in), optional                  :: area_to_remove     ! area of currentPatch to remove, the rest goes to newpatch
+    type(bc_out_type)   , intent(inout)             :: bc_out
     !
     ! !LOCAL VARIABLES:
     integer  :: el                           ! element loop index
@@ -1679,7 +1682,10 @@ contains
 
     call CopyPatchMeansTimers(currentPatch, new_patch)
 
-    call TransLitterNewPatch( currentSite, currentPatch, new_patch, temp_area, 0)
+    call TransLitterNewPatch( currentSite, currentPatch, new_patch, temp_area, bc_out)
+
+    currentPatch%burnt_frac_litter(:) = 0._r8
+
 
     ! Next, we loop through the cohorts in the donor patch, copy them with
     ! area modified number density into the new-patch, and apply survivorship.
@@ -1813,8 +1819,7 @@ contains
   subroutine TransLitterNewPatch(currentSite,        &
                                  currentPatch,       &
                                  newPatch,           &
-                                 patch_site_areadis, &
-                                 dist_type)
+                                 patch_site_areadis, bc_out)
 
     ! -----------------------------------------------------------------------------------
     ! 
@@ -1863,7 +1868,7 @@ contains
     type(fates_patch_type) , intent(inout) :: newPatch           ! New patch
     real(r8)            , intent(in)    :: patch_site_areadis ! Area being donated
                                                               ! by current patch
-    integer,              intent(in)    :: dist_type          ! disturbance type
+    type(bc_out_type)   , intent(inout)         :: bc_out
 
     
     ! locals
@@ -1989,7 +1994,7 @@ contains
 
           site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-          bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass
+          bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
 
           ! Transfer below ground CWD (none burns)
           
@@ -2020,7 +2025,7 @@ contains
            
            site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-           bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass
+           bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
 
            ! Transfer root fines (none burns)
            do sl = 1,currentSite%nlevsoil
@@ -2091,7 +2096,7 @@ contains
     type(fates_patch_type) , intent(inout), target :: newPatch   ! New Patch
     real(r8)            , intent(in)            :: patch_site_areadis ! Area being donated
     type(bc_in_type)    , intent(in)            :: bc_in
-    type(bc_out_type)   , intent(in)            :: bc_out
+    type(bc_out_type)   , intent(inout)         :: bc_out
     
     !
     ! !LOCAL VARIABLES:
@@ -2233,7 +2238,7 @@ contains
 
              site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-             bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass
+             bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
 
              call set_root_fraction(currentSite%rootfrac_scr, pft, currentSite%zi_soil, &
                   bc_in%max_rooting_depth_index_col)
@@ -2296,7 +2301,7 @@ contains
                       burned_mass = num_dead_trees * SF_val_CWD_frac_adj(c) * bstem * &
                       currentCohort%fraction_crown_burned
                       site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
-                      bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass
+                      bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
                 endif
                 new_litt%ag_cwd(c) = new_litt%ag_cwd(c) + donatable_mass * donate_m2
                 curr_litt%ag_cwd(c) = curr_litt%ag_cwd(c) + donatable_mass * retain_m2
@@ -2564,7 +2569,7 @@ contains
     type(fates_patch_type) , intent(inout), target :: newPatch   ! New Patch
     real(r8)               , intent(in)            :: patch_site_areadis ! Area being donated
     type(bc_in_type)       , intent(in)            :: bc_in
-    type(bc_out_type)      , intent(in)            :: bc_out
+    type(bc_out_type)      , intent(inout)         :: bc_out
     logical                , intent(in)            :: clearing_matrix_element ! whether or not to clear vegetation
 
     !
@@ -2709,7 +2714,7 @@ contains
 
              site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-             bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass
+             bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
 
              call set_root_fraction(currentSite%rootfrac_scr, pft, currentSite%zi_soil, &
                   bc_in%max_rooting_depth_index_col)
@@ -2770,7 +2775,7 @@ contains
                         EDPftvarcon_inst%landusechange_frac_burned(pft)
 
                    site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
-                   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass
+                   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
                 else ! all other pools can end up as timber products or burn or go to litter
                    donatable_mass = donatable_mass * (1.0_r8-EDPftvarcon_inst%landusechange_frac_exported(pft)) * &
                         (1.0_r8-EDPftvarcon_inst%landusechange_frac_burned(pft))
@@ -2784,7 +2789,7 @@ contains
 
                    site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-                   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass
+                   bc_out%fire_closs_to_atm_si = bc_out%fire_closs_to_atm_si + burned_mass * ha_per_m2 * days_per_sec
 
                    trunk_product_site = trunk_product_site + &
                         woodproduct_mass

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -756,7 +756,7 @@ contains
                             call CopyPatchMeansTimers(currentPatch, newPatch)
 
 
-                            call TransLitterNewPatch( currentSite, currentPatch, newPatch, patch_site_areadis, bc_out)
+                            call TransLitterNewPatch( currentSite, currentPatch, newPatch, patch_site_areadis, bc_out, i_disturbance_type)
 
 
                             ! Transfer in litter fluxes from plants in various contexts of death and destruction
@@ -1682,9 +1682,7 @@ contains
 
     call CopyPatchMeansTimers(currentPatch, new_patch)
 
-    call TransLitterNewPatch( currentSite, currentPatch, new_patch, temp_area, bc_out)
-
-    currentPatch%burnt_frac_litter(:) = 0._r8
+    call TransLitterNewPatch( currentSite, currentPatch, new_patch, temp_area, bc_out, 0)
 
 
     ! Next, we loop through the cohorts in the donor patch, copy them with
@@ -1819,7 +1817,7 @@ contains
   subroutine TransLitterNewPatch(currentSite,        &
                                  currentPatch,       &
                                  newPatch,           &
-                                 patch_site_areadis, bc_out)
+                                 patch_site_areadis, bc_out, dist_type)
 
     ! -----------------------------------------------------------------------------------
     ! 
@@ -1869,7 +1867,7 @@ contains
     real(r8)            , intent(in)    :: patch_site_areadis ! Area being donated
                                                               ! by current patch
     type(bc_out_type)   , intent(inout)         :: bc_out
-
+    integer,              intent(in)    :: dist_type          ! disturbance type
     
     ! locals
     type(site_massbal_type), pointer :: site_mass

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -429,7 +429,7 @@ contains
 
   ! ============================================================================
 
-  subroutine PreDisturbanceLitterFluxes( currentSite, currentPatch, bc_in )
+  subroutine PreDisturbanceLitterFluxes( currentSite, currentPatch, bc_in, bc_out )
 
     ! -----------------------------------------------------------------------------------
     !
@@ -437,8 +437,7 @@ contains
     ! associated with seed turnover, seed influx, litterfall from live and
     ! dead plants, germination, and fragmentation.
     !
-    ! At this time we do not have explicit herbivory, and burning losses to litter
-    ! are handled elsewhere.
+    ! Herbivory is handled here. burning losses to litter are handled elsewhere.
     !
     ! Note: The processes conducted here DO NOT handle litter fluxes associated
     !       with disturbance.  Those fluxes are handled elsewhere (EDPatchDynamcisMod)
@@ -452,6 +451,7 @@ contains
     type(ed_site_type), intent(inout)  :: currentSite
     type(fates_patch_type), intent(inout) :: currentPatch
     type(bc_in_type), intent(in)       :: bc_in
+    type(bc_out_type), intent(in)      :: bc_out
 
     !
     ! !LOCAL VARIABLES:
@@ -470,34 +470,34 @@ contains
                   site_mass => currentSite%mass_balance(el), &
                   diag => currentSite%flux_diags%elem(el))
 
-         ! Calculate loss rate of viable seeds to litter
-         call SeedDecay(litt, currentPatch, bc_in)
-         
-         ! Calculate seed germination rate, the status flags prevent
-         ! germination from occuring when the site is in a drought
-         ! (for drought deciduous) or too cold (for cold deciduous)
-         call SeedGermination(litt, currentSite%cstatus, currentSite%dstatus(1:numpft), bc_in, currentPatch)
-         
-         ! Send fluxes from newly created litter into the litter pools
-         ! This litter flux is from non-disturbance inducing mortality, as well
-         ! as litter fluxes from live trees
-         call CWDInput(currentSite, currentPatch, litt,bc_in)
-         
-         ! Only calculate fragmentation flux over layers that are active
-         ! (RGK-Mar2019) SHOULD WE MAX THIS AT 1? DONT HAVE TO
-         
-         nlev_eff_decomp = max(bc_in%max_rooting_depth_index_col, 1)
-         call CWDOut(litt,currentPatch%fragmentation_scaler,nlev_eff_decomp)
-         
-         ! Fragmentation flux to soil decomposition model [kg/site/day]
-         site_mass%frag_out = site_mass%frag_out + currentPatch%area * &
-              ( sum(litt%ag_cwd_frag) + sum(litt%bg_cwd_frag) + &
-              sum(litt%leaf_fines_frag) + sum(litt%root_fines_frag) + &
-              sum(litt%seed_decay) + sum(litt%seed_germ_decay))
-         
-         ! Track total seed decay diagnostic in [kg/m2/day]
-         diag%tot_seed_turnover = diag%tot_seed_turnover + &
-              (sum(litt%seed_decay) + sum(litt%seed_germ_decay))*currentPatch%area*area_inv
+       ! Calculate loss rate of viable seeds to litter
+       call SeedDecay(litt, currentPatch, bc_in)
+       
+
+       ! Calculate seed germination rate, the status flags prevent
+       ! germination from occuring when the site is in a drought
+       ! (for drought deciduous) or too cold (for cold deciduous)
+       call SeedGermination(litt, currentSite%cstatus, currentSite%dstatus(1:numpft), bc_in, currentPatch)
+
+       ! Send fluxes from newly created litter into the litter pools
+       ! This litter flux is from non-disturbance inducing mortality, as well
+       ! as litter fluxes from live trees
+       call CWDInput(currentSite, currentPatch, litt,bc_in, bc_out)
+
+       ! Only calculate fragmentation flux over layers that are active
+       ! (RGK-Mar2019) SHOULD WE MAX THIS AT 1? DONT HAVE TO
+
+       nlev_eff_decomp = max(bc_in%max_rooting_depth_index_col, 1)
+       call CWDOut(litt,currentPatch%fragmentation_scaler,nlev_eff_decomp)
+
+       site_mass => currentSite%mass_balance(el)
+
+       ! Fragmentation flux to soil decomposition model [kg/site/day]
+       site_mass%frag_out = site_mass%frag_out + currentPatch%area * &
+            ( sum(litt%ag_cwd_frag) + sum(litt%bg_cwd_frag) + &
+            sum(litt%leaf_fines_frag) + sum(litt%root_fines_frag) + &
+            sum(litt%seed_decay) + sum(litt%seed_germ_decay))
+
 
        end associate
     end do
@@ -2788,7 +2788,7 @@ contains
 
    ! ======================================================================================
 
-  subroutine CWDInput( currentSite, currentPatch, litt, bc_in)
+  subroutine CWDInput( currentSite, currentPatch, litt, bc_in, bc_out)
 
     !
     ! !DESCRIPTION:
@@ -2808,6 +2808,7 @@ contains
     type(fates_patch_type),intent(inout), target :: currentPatch
     type(litter_type),intent(inout),target    :: litt
     type(bc_in_type),intent(in)               :: bc_in
+    type(bc_out_type),intent(in)              :: bc_out
 
     !
     ! !LOCAL VARIABLES:
@@ -2955,10 +2956,13 @@ contains
             elflux_diags%root_litter_input(pft) +  &
             (fnrt_m_turnover + store_m_turnover ) * currentCohort%n
 
-       ! send the part of the herbivory flux that doesn't go to litter to the atmosphere
+       ! send the part of the herbivory flux that doesn't go to litter to the atmosphere (and also for tracking)
 
        site_mass%herbivory_flux_out = &
             site_mass%herbivory_flux_out + &
+            leaf_herbivory * (1._r8 - herbivory_element_use_efficiency) * currentCohort%n
+
+       bc_out%grazing_closs_to_atm_si = bc_out%grazing_closs_to_atm_si + &
             leaf_herbivory * (1._r8 - herbivory_element_use_efficiency) * currentCohort%n
 
        ! Assumption: turnover from deadwood and sapwood are lumped together in CWD pool

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -33,6 +33,8 @@ module EDPhysiologyMod
   use FatesConstantsMod, only    : megajoules_per_joule
   use FatesConstantsMod, only    : mpa_per_mm_suction
   use FatesConstantsMod, only    : g_per_kg
+  use FatesConstantsMod, only    : ha_per_m2
+  use FatesConstantsMod, only    : days_per_sec
   use FatesConstantsMod, only    : ndays_per_year
   use FatesConstantsMod, only    : nocomp_bareground
   use FatesConstantsMod, only    : nocomp_bareground_land
@@ -490,7 +492,6 @@ contains
        nlev_eff_decomp = max(bc_in%max_rooting_depth_index_col, 1)
        call CWDOut(litt,currentPatch%fragmentation_scaler,nlev_eff_decomp)
 
-       site_mass => currentSite%mass_balance(el)
 
        ! Fragmentation flux to soil decomposition model [kg/site/day]
        site_mass%frag_out = site_mass%frag_out + currentPatch%area * &

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -451,7 +451,7 @@ contains
     type(ed_site_type), intent(inout)  :: currentSite
     type(fates_patch_type), intent(inout) :: currentPatch
     type(bc_in_type), intent(in)       :: bc_in
-    type(bc_out_type), intent(in)      :: bc_out
+    type(bc_out_type), intent(inout)   :: bc_out
 
     !
     ! !LOCAL VARIABLES:
@@ -2808,7 +2808,7 @@ contains
     type(fates_patch_type),intent(inout), target :: currentPatch
     type(litter_type),intent(inout),target    :: litt
     type(bc_in_type),intent(in)               :: bc_in
-    type(bc_out_type),intent(in)              :: bc_out
+    type(bc_out_type),intent(inout)           :: bc_out
 
     !
     ! !LOCAL VARIABLES:
@@ -2963,7 +2963,8 @@ contains
             leaf_herbivory * (1._r8 - herbivory_element_use_efficiency) * currentCohort%n
 
        bc_out%grazing_closs_to_atm_si = bc_out%grazing_closs_to_atm_si + &
-            leaf_herbivory * (1._r8 - herbivory_element_use_efficiency) * currentCohort%n
+            leaf_herbivory * (1._r8 - herbivory_element_use_efficiency) * currentCohort%n * &
+            ha_per_m2 * days_per_sec
 
        ! Assumption: turnover from deadwood and sapwood are lumped together in CWD pool
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2255,7 +2255,7 @@ contains
 
           ! Default seed decay (TRS is off)
           litt%seed_decay(pft) = litt%seed(pft) * &
-               EDPftvarcon_inst%seed_decay_rate(pft)*years_per_day
+               EDPftvarcon_inst%seed_decay_rate(pft)*years_per_day * 0._r8 !THIS IS A HACK 
 
        end if
 
@@ -3238,7 +3238,7 @@ contains
       endif ! scalar
 
     endif ! not bare ground
-
+     currentPatch%fragmentation_scaler(:) =0._r8 !this is a hack
   end subroutine fragmentation_scaler
 
   ! ============================================================================
@@ -3278,7 +3278,7 @@ contains
     do c = 1,ncwd
 
        litt%ag_cwd_frag(c)   = litt%ag_cwd(c) * SF_val_max_decomp(c) * &
-             years_per_day * fragmentation_scaler(soil_layer_index)
+             years_per_day * fragmentation_scaler(soil_layer_index) * 0.0_r8 ! THIS IS A HACK
 
        do ilyr = 1,nlev_eff_decomp
            litt%bg_cwd_frag(c,ilyr) = litt%bg_cwd(c,ilyr) * SF_val_max_decomp(c) * &

--- a/biogeochem/FatesSoilBGCFluxMod.F90
+++ b/biogeochem/FatesSoilBGCFluxMod.F90
@@ -744,10 +744,10 @@ contains
 
              do id = 1,nlev_eff_decomp
                 flux_cel_si(id) = flux_cel_si(id) + &
-                     litt%ag_cwd_frag(ic) * ED_val_cwd_fcel * area_frac * surface_prof(id)
+                     litt%ag_cwd_frag(ic) * ED_val_cwd_fcel * area_frac * surface_prof(id) *0._r8 !THIS IS A HACK
 
                 flux_lig_si(id) = flux_lig_si(id) + & 
-                     litt%ag_cwd_frag(ic) * ED_val_cwd_flig * area_frac * surface_prof(id)
+                     litt%ag_cwd_frag(ic) * ED_val_cwd_flig * area_frac * surface_prof(id) *0._r8 ! this is a hack
                 
              end do
 
@@ -809,6 +809,7 @@ contains
              flux_lig_si(id) = flux_lig_si(id) + &
                   litt%root_fines_frag(ilignin,j) * area_frac
           enddo
+          
 
           currentPatch => currentPatch%younger
        end do

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -294,7 +294,7 @@ contains
     ! make new patches from disturbed land
     if (do_patch_dynamics.eq.itrue ) then
 
-       call spawn_patches(currentSite, bc_in)
+       call spawn_patches(currentSite, bc_in, bc_out)
 
        call TotalBalanceCheck(currentSite,3)
 
@@ -782,7 +782,7 @@ contains
        
        call GenerateDamageAndLitterFluxes( currentSite, currentPatch, bc_in)
 
-       call PreDisturbanceLitterFluxes( currentSite, currentPatch, bc_in)
+       call PreDisturbanceLitterFluxes( currentSite, currentPatch, bc_in, bc_out)
 
        call PreDisturbanceIntegrateLitter(currentPatch )
 

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -320,7 +320,6 @@ contains
     ! Final instantaneous mass balance check
     call TotalBalanceCheck(currentSite,5)
 
-    
   end subroutine ed_ecosystem_dynamics
 
   !-------------------------------------------------------------------------------!
@@ -641,7 +640,7 @@ contains
           bc_out%ar_site = bc_out%ar_site + (currentCohort%resp_m_acc_hold + &
                currentCohort%resp_g_acc_hold + currentCohort%resp_excess_hold) * & 
                AREA_INV * currentCohort%n / hlm_days_per_year / sec_per_day
-          
+
           
           ! Update the mass balance tracking for the daily nutrient uptake flux
           ! Then zero out the daily uptakes, they have been used
@@ -835,6 +834,11 @@ contains
     type(bc_out_type)  , intent(inout)    :: bc_out
     logical,intent(in)                    :: is_restarting ! is this called during restart read?
     !
+    real(r8) :: biomass_stock   ! total biomass   in Kg/site    
+    real(r8) :: litter_stock    ! total litter    in Kg/site
+    real(r8) :: seed_stock      ! total seed mass in Kg/site
+    real(r8) :: total_stock     ! total ED carbon in Kg/site
+
     ! !LOCAL VARIABLES:
     type (fates_patch_type) , pointer :: currentPatch
     !-----------------------------------------------------------------------
@@ -856,6 +860,9 @@ contains
 
     call TotalBalanceCheck(currentSite,final_check_id)
 
+    call SiteMassStock(currentSite,1,total_stock,biomass_stock,litter_stock,seed_stock)
+    bc_out%fates_total_carbon_site = total_stock
+    
     ! Update recruit L2FRs based on new canopy position
     call SetRecruitL2FR(currentSite)
     
@@ -968,7 +975,7 @@ contains
        call SiteMassStock(currentSite,el,total_stock,biomass_stock,litter_stock,seed_stock)
 
        change_in_stock = total_stock - site_mass%old_stock
-
+       
        flux_in  = site_mass%seed_in + &
                   site_mass%net_root_uptake + &
                   site_mass%gpp_acc + &

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -682,7 +682,11 @@ contains
                currentCohort%resp_m_acc*currentCohort%n + & 
                (currentCohort%resp_g_acc_hold+currentCohort%resp_excess_hold) * &
                currentCohort%n/real( hlm_days_per_year,r8)
+          
+          write(*,*) 'EDM:acc stgpp',site_cmass%gpp_acc, currentCohort%gpp_acc * currentCohort%n
 
+          write(*,*) 'EDM:acc stresp',site_cmass%aresp_acc ,
+          
           call currentCohort%prt%CheckMassConservation(ft,5)
 
           ! Update the leaf biophysical rates based on proportion of leaf
@@ -827,6 +831,8 @@ contains
     !
     ! !USES:
     use EDCanopyStructureMod , only : canopy_spread, canopy_structure
+    use EDTypesMod , only : AREA ! m2. Area of site
+    use FatesConstantsMod        , only : g_per_kg
     !
     ! !ARGUMENTS:
     type(ed_site_type) , intent(inout), target :: currentSite
@@ -861,7 +867,9 @@ contains
     call TotalBalanceCheck(currentSite,final_check_id)
 
     call SiteMassStock(currentSite,1,total_stock,biomass_stock,litter_stock,seed_stock)
-    bc_out%fates_total_carbon_site = total_stock
+    ! convert from kgC/site to gC/m2 
+    bc_out%fates_total_carbon_site = total_stock * g_per_kg/AREA
+    write(*,*) 'total_stock F3, B-L-S',total_stock*g_per_kg/AREA,biomass_stock* g_per_kg/AREA,litter_stock* g_per_kg/AREA,seed_stock* g_per_kg/AREA
     
     ! Update recruit L2FRs based on new canopy position
     call SetRecruitL2FR(currentSite)
@@ -994,7 +1002,9 @@ contains
        net_flux        = flux_in - flux_out
        error           = abs(net_flux - change_in_stock)
 
-
+       write(*,*) 'fatesBALC: netf,chst',net_flux/10._r8,change_in_stock/10._r8
+       write(*,*) 'fatesBALC: net npp',(site_mass%gpp_acc - site_mass%aresp_acc)/10._r8
+       write(*,*) 'fatesBALC: news, olds', total_stock/10._r8, site_mass%old_stock/10._r8
        if(change_in_stock>0.0)then
           error_frac      = error/abs(total_stock)
        else

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -8530,7 +8530,7 @@ contains
             upfreq=group_hifr_simple, ivar=ivar, initialize=initialize_variables,                &
             index = ih_livestem_mr_si)
 
-       call this%set_history_var(vname='FATES_NEP', units='kg m-2 s-1',           &
+       call this%set_history_var(vname='FATES_NEP_INT', units='kg m-2 s-1',           &
             long='net ecosystem production in kg carbon per m2 per second',      &
             use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',    &
             upfreq=group_hifr_simple, ivar=ivar, initialize=initialize_variables,                &

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -373,8 +373,8 @@ contains
     end select
 
     ! carbon loss to atmosphere pathways
-    fates%bc_out(s)%grazing_closs_to_atm_si(:) = 0.0_r8
-    fates%bc_out(s)%fire_closs_to_atm_si(:)    = 0.0_r8
+    fates%bc_out(s)%grazing_closs_to_atm_si = 0.0_r8
+    fates%bc_out(s)%fire_closs_to_atm_si    = 0.0_r8
 
     fates%bc_out(s)%rssun_pa(:)     = 0.0_r8
     fates%bc_out(s)%rssha_pa(:)     = 0.0_r8

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -371,7 +371,11 @@ contains
        write(fates_log(), *) 'hlm_parteh_mode: ',hlm_parteh_mode
        call endrun(msg=errMsg(sourcefile, __LINE__))
     end select
-    
+
+    ! carbon loss to atmosphere pathways
+    fates%bc_out(s)%grazing_closs_to_atm_si(:) = 0.0_r8
+    fates%bc_out(s)%fire_closs_to_atm_si(:)    = 0.0_r8
+
     fates%bc_out(s)%rssun_pa(:)     = 0.0_r8
     fates%bc_out(s)%rssha_pa(:)     = 0.0_r8
     

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -412,6 +412,9 @@ contains
     ! Land Use realated
     fates%bc_out(s)%gpp_site = 0.0_r8
     fates%bc_out(s)%ar_site = 0.0_r8
+    fates%bc_out(s)%npp_site = 0.0_r8
+    fates%bc_out(s)%npp_acc_site = 0.0_r8
+    fates%bc_out(s)%fates_total_carbon_site = 0.0_r8
     fates%bc_out(s)%hrv_deadstemc_to_prod10c = 0.0_r8
     fates%bc_out(s)%hrv_deadstemc_to_prod100c = 0.0_r8
 

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -823,6 +823,10 @@ module FatesInterfaceTypesMod
       real(r8) :: gpp_site  ! Site level GPP, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
       real(r8) :: ar_site   ! Site level Autotrophic Resp, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
 
+      ! direct carbon loss to atm pathways
+      real(r8) :: grazing_closs_to_atm_si    ! Loss of carbon to atmosphere via grazing [Site-Level, gC m-2 s-1]
+      real(r8) :: fire_closs_to_atm_si       ! Loss of carbon to atmosphere via burning (includes burning from land use change) [Site-Level, gC m-2 s-1]
+
    end type bc_out_type
 
 

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -822,7 +822,10 @@ module FatesInterfaceTypesMod
       real(r8) :: hrv_deadstemc_to_prod100c  ! Harvested C flux to 100-yr wood product pool [Site-Level, gC m-2 s-1]
       real(r8) :: gpp_site  ! Site level GPP, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
       real(r8) :: ar_site   ! Site level Autotrophic Resp, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
-
+      real(r8) :: npp_site  ! Site level timestep-specific NPP, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
+      real(r8) :: npp_acc_site ! Sitelevel, timestep-specific accumulated NPP to account for assimilate but not allocated C in HLM balance check
+      real(r8) :: fates_total_carbon_site ! Site level total carbon in FATES (g/m2) for  HLM balance check
+      
       ! direct carbon loss to atm pathways
       real(r8) :: grazing_closs_to_atm_si    ! Loss of carbon to atmosphere via grazing [Site-Level, gC m-2 s-1]
       real(r8) :: fire_closs_to_atm_si       ! Loss of carbon to atmosphere via burning (includes burning from land use change) [Site-Level, gC m-2 s-1]

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -823,7 +823,8 @@ module FatesInterfaceTypesMod
       real(r8) :: gpp_site  ! Site level GPP, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
       real(r8) :: ar_site   ! Site level Autotrophic Resp, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
       real(r8) :: npp_site  ! Site level timestep-specific NPP, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
-      real(r8) :: npp_acc_site ! Sitelevel, timestep-specific accumulated NPP to account for assimilate but not allocated C in HLM balance check. gC/m2 
+      real(r8) :: npp_acc_site ! Sitelevel, timestep-specific accumulated NPP to account for assimilate but not allocated C in HLM balance check. gC/m2
+      real(r8) :: gresp_site ! Sitelevel, daily growth respiration flux gC/m2/day to be added to unreleased carbon pool. 
       real(r8) :: fates_total_carbon_site ! Site level total carbon in FATES (g/m2) for  HLM balance check
       
       ! direct carbon loss to atm pathways

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -823,7 +823,7 @@ module FatesInterfaceTypesMod
       real(r8) :: gpp_site  ! Site level GPP, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
       real(r8) :: ar_site   ! Site level Autotrophic Resp, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
       real(r8) :: npp_site  ! Site level timestep-specific NPP, for NBP diagnosis in HLM [Site-Level, gC m-2 s-1]
-      real(r8) :: npp_acc_site ! Sitelevel, timestep-specific accumulated NPP to account for assimilate but not allocated C in HLM balance check
+      real(r8) :: npp_acc_site ! Sitelevel, timestep-specific accumulated NPP to account for assimilate but not allocated C in HLM balance check. gC/m2 
       real(r8) :: fates_total_carbon_site ! Site level total carbon in FATES (g/m2) for  HLM balance check
       
       ! direct carbon loss to atm pathways


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This code adds the FATES-side modifications to allow Net Biome Productivity fluxes to be passed back to the atmosphere. The changes on the FATES side are largely taken from @ckoven 's work on this branch: 

https://github.com/ckoven/fates/compare/twostream-restart-bugfixes-shijiefix...ckoven:fates:nbp_diagnostics

This code is paired with a CTSM-side PR:
https://github.com/NorESMhub/CTSM/pull/137

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

