### PR TITLE
Simple muting of logging statement

### DIFF
--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -271,7 +271,8 @@ contains
          if (site_secondaryland_first_exceeding_min) then
             if ( patch_land_use_label .eq. primaryland) then
                harvest_rate = state_vector(secondaryland) / state_vector(primaryland)
-               write(fates_log(), *) 'applying state_vector(secondaryland) to plants.', pft_i
+               ! This log statement caused an enormous number of log-statements, muting for now
+               ! write(fates_log(), *) 'applying state_vector(secondaryland) to plants.', pft_i
             else
                harvest_rate = 0._r8
             endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
Simply commenting out logging, from logging which totally clogs the logfiles to an unreadable state when running with landuse. 

### Collaborators:


### Expectation of Answer Changes:
Expect no answers changes, just shorter and more readable log when running with landuse.

### Checklist

