### PR TITLE
alter hydraulic failure mortality logic

### DIFF
--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -184,7 +184,7 @@ contains
           if ( (.not. is_decid_dormant) .and. &
                ( btran_ft(cohort_in%pft) <= hf_sm_threshold ) .and. &
                ( ( minval(bc_in%t_soisno_sl) - tfrz ) > soil_tfrz_thresh ) ) then
-             hmort = EDPftvarcon_inst%mort_scalar_hydrfailure(cohort_in%pft)
+             hmort = EDPftvarcon_inst%mort_scalar_hydrfailure(cohort_in%pft)*((hf_sm_threshold- btran_ft(cohort_in%pft))/hf_sm_threshold)
           else
              hmort = 0.0_r8
           end if


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a minor change to how hydraulic failure mortality is calculated. 
Previously, below the threshold, mortality occured at the rate dicated by the _mort_scalar_hydrfailure_
This lead to behaviour with very abrupt thresholds and no sensitivity to altered soil moisture status in long vs short droughts. 
This logic was nver important before because the default hf_sm_threshold parameters were very close to zero. Making them larger brings this mechanism into play. 
The function, as all the other mortality functions, is a bit arbitrary and scales mortality to be equal to the mort_scalar_hydrfailure when _btran_ is zero. Below the _hf_sm_threshold_ mortality begins to ramp up as a function of the difference between btran and the threshold. 


### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
This will changes answers, in dry places. 
The differences introduced by this PR are illustrated here:
https://ns9560k.web.sigma2.no/datalake/diagnostics/noresm/rosief/i2000.f45_f45_mg37.fates-nocomp.beta01.v22i/compare/i2000.f45_f45_mg37.fates-nocomp.beta01.v22h/

Here for example is the change in LAI, which as anticipated is mostly in semi arid regions. The magnitude of the effect depends on the settings for the relevant parameters (these are largely unknown, and part of the purpose of FATES is to introduce and expose these types of mortality mechanisms to validation and calibration). 

<img width="3000" height="1000" alt="image" src="https://github.com/user-attachments/assets/65933417-96ff-4119-8d8d-734622b1f7a6" />



### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My change requires a change to the documentation. **This would be true if it were being wrapped back into the main FATES repo**
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ x] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

