### PR TITLE
Seedbank coldstart

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -667,6 +667,7 @@ contains
     real(r8) :: newparea, newparea_withlanduse
     real(r8) :: total !check on area
     real(r8) :: litt_init  !invalid for satphen, 0 otherwise
+    real(r8) :: seed_init ! start seedbank at this value for each PFT. 
     real(r8) :: old_carea
     logical  :: is_first_patch
     ! integer  :: n_luh_states
@@ -802,13 +803,14 @@ contains
                    litt_init = fates_unset_r8
                 else
                    litt_init = 0._r8
+                   seed_init = 0.01_r8  ! This should maybe be a parameter ultimately. Leaving here to avoid changing the api. 
                 end if
                 do el=1,num_elements
                    call newp%litter(el)%InitConditions(init_leaf_fines=litt_init, &
                         init_root_fines=litt_init, &
                         init_ag_cwd=litt_init, &
                         init_bg_cwd=litt_init, &
-                        init_seed=litt_init,   &
+                        init_seed=seed_init,   &
                         init_seed_germ=litt_init)
                 end do
 

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -804,14 +804,13 @@ contains
                    seed_init = fates_unset_r8
                 else
                    litt_init = 0._r8
-                   seed_init = 0.01_r8  ! This should maybe be a parameter ultimately. Leaving here to avoid changing the api. 
                 end if
                 do el=1,num_elements
                    call newp%litter(el)%InitConditions(init_leaf_fines=litt_init, &
                         init_root_fines=litt_init, &
                         init_ag_cwd=litt_init, &
                         init_bg_cwd=litt_init, &
-                        init_seed=seed_init,   &
+                        init_seed=litt_init,   &
                         init_seed_germ=litt_init)
                 end do
 
@@ -896,12 +895,25 @@ contains
                             litt_init = 0._r8
                          end if
                          do el=1,num_elements
-                            call newp%litter(el)%InitConditions(init_leaf_fines=litt_init, &
-                                 init_root_fines=litt_init, &
-                                 init_ag_cwd=litt_init, &
-                                 init_bg_cwd=litt_init, &
-                                 init_seed=litt_init,   &
-                                 init_seed_germ=litt_init)
+                            if ((.not. hlm_use_sp .eq. itrue) .and. &
+                                (.not. (newp%nocomp_pft_label .eq. fates_unset_int) .or. &
+                                       (newp%nocomp_pft_label .eq. nocomp_bareground))) then
+                               ! nocomp non-bareground get inital seed pool from the parameter file
+                               ! sp mode will get unset values no matter what
+                               call newp%litter(el)%InitConditions(init_leaf_fines=litt_init, &
+                                    init_root_fines=litt_init, &
+                                    init_ag_cwd=litt_init, &
+                                    init_bg_cwd=litt_init, &
+                                    init_seed=EDPftvarcon_inst%init_seed(newp%nocomp_pft_label),   &
+                                    init_seed_germ=litt_init)
+                            else
+                               call newp%litter(el)%InitConditions(init_leaf_fines=litt_init, &
+                                   init_root_fines=litt_init, &
+                                   init_ag_cwd=litt_init, &
+                                   init_bg_cwd=litt_init, &
+                                   init_seed=litt_init,   &
+                                   init_seed_germ=litt_init)
+                            endif
                          end do
 
                          sitep => sites(s)

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -801,6 +801,7 @@ contains
                 ! and transfering in mass
                 if(hlm_use_sp.eq.itrue)then
                    litt_init = fates_unset_r8
+                   seed_init = fates_unset_r8
                 else
                    litt_init = 0._r8
                    seed_init = 0.01_r8  ! This should maybe be a parameter ultimately. Leaving here to avoid changing the api. 

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -61,6 +61,7 @@ module EDPftvarcon
                                                      ! with competition on (i.e. not nocomp)
      real(r8), allocatable :: initd_nocomp(:)        ! either initial seedling density or initial
                                                      ! plant size for nocomp runs
+     real(r8), allocatable :: init_seed(:)              ! initial seed pool 
      real(r8), allocatable :: seed_suppl(:)          ! seeds that come from outside the gridbox.
 
      real(r8), allocatable :: lf_flab(:)             ! Leaf litter labile fraction [-]
@@ -389,6 +390,10 @@ contains
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
     name = 'fates_recruit_init_nocomp'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_init_seed'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
@@ -812,6 +817,10 @@ contains
     name = 'fates_recruit_init_nocomp'
     call fates_params%RetrieveParameterAllocate(name=name, &
          data=this%initd_nocomp)
+
+    name = 'fates_init_seed'
+    call fates_params%RetrieveParameterAllocate(name=name, &
+         data=this%init_seed)
 
     name = 'fates_recruit_seed_supplement'
     call fates_params%RetrieveParameterAllocate(name=name, &
@@ -1612,6 +1621,7 @@ contains
         write(fates_log(),fmt0) 'crown_kill = ',EDPftvarcon_inst%crown_kill
         write(fates_log(),fmt0) 'initd_fullfates = ',EDPftvarcon_inst%initd_fullfates
         write(fates_log(),fmt0) 'initd_nocomp = ',EDPftvarcon_inst%initd_nocomp
+        write(fates_log(),fmt0) 'init_seed = ',EDPftvarcon_inst%init_seed
         write(fates_log(),fmt0) 'seed_suppl = ',EDPftvarcon_inst%seed_suppl
         write(fates_log(),fmt0) 'lf_flab = ',EDPftvarcon_inst%lf_flab
         write(fates_log(),fmt0) 'lf_fcel = ',EDPftvarcon_inst%lf_fcel
@@ -2043,6 +2053,11 @@ contains
            call endrun(msg=errMsg(sourcefile, __LINE__))
            
         end if
+
+        if ( EDPftvarcon_inst%init_seed(ipft) .lt. 0.0_r8) then
+           write(fates_log(),*) ' Initial seed pool fates_init_seed can not be negative.'
+           call endrun(msg=errMsg(sourcefile, __LINE__))
+        endif
            
 
         ! Check to make sure that if a grass sapwood allometry is used, it is not

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -814,7 +814,7 @@ contains
      currentPatch => this%oldest_patch
      do while (associated(currentPatch))
         if (currentPatch%land_use_label .eq. secondaryland) then
-           if ( currentPatch%age .ge. secondary_age_threshold ) then
+           if ( currentPatch%age_since_anthro_disturbance .ge. secondary_age_threshold ) then
               secondary_old_area = secondary_old_area + currentPatch%area
            else
               secondary_young_area = secondary_young_area + currentPatch%area

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -555,6 +555,9 @@ variables:
 	double fates_recruit_init_nocomp(fates_pft) ;
 		fates_recruit_init_nocomp:units = "stems/m2 or dbh cm" ;
 		fates_recruit_init_nocomp:long_name = "initial seedling density or initial size of seedlings (if negative) in nocomp mode" ;
+	double fates_init_seed(fates_pft) ;
+		fates_init_seed:units = "kg/m2" ;
+		fates_init_seed:long_name = "initial seed pool (only applied)" ;
 	double fates_recruit_prescribed_rate(fates_pft) ;
 		fates_recruit_prescribed_rate:units = "n/yr" ;
 		fates_recruit_prescribed_rate:long_name = "recruitment rate for prescribed physiology mode" ;
@@ -1544,6 +1547,9 @@ data:
 
  fates_recruit_init_nocomp =  -1, -1, -1, -1, -1, -1, -1, -1, -2, -2, -6, -6, 
     -6, -2 ;
+
+fates_init_seed = 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 
+    0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01 ;
 
  fates_recruit_prescribed_rate = 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 
     0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02 ;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This introduces the initialization of the seed bank in FATES as a non-zero number, to prevent extinctions due to moisture and temperature fluctuation in the early parts of the run. 

@mvdebolskiy if you want me to append this to the https://github.com/NorESMhub/fates/pull/32 then let me know... 

### Description:
These are v simple changes and probably don't need explanation. 

### Collaborators:
Jessie Needham (who I can't tag yet?) @kjetilaas @maritsandstad @mvdebolskiy 

### Expectation of Answer Changes:
Answers will change in most cases but the impacts are greatest in marginal places. The output of a run with (26x) and eithouth (26w) these changes is here. 
https://ns9560k.web.sigma2.no/datalake/diagnostics/noresm/rosief/i2000.f45_f45_mg37.fates-nocomp.beta02.v26x_CRUJRAa/compare/i2000.f45_f45_mg37.fates-nocomp.beta02.v26w_CRUJRAa/ANN/

and is perhaps best illustrated by the changes in total plant area
<img width="3000" height="1000" alt="image" src="https://github.com/user-attachments/assets/59ce1140-6887-4a50-8342-0da26532385f" />

The magnitude and location of the change are conditional on the previous state. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

