### PR TITLE
Add new param for nocomp initialisation

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -1095,13 +1095,14 @@ contains
       patch_in%shortest => null()
 
       ! if any pfts are starting with large  size  then the whole  site needs a spread of 0
-      do pft = 1, numpft
-         if (EDPftvarcon_inst%initd(pft) < 0.0_r8) then   
-            site_in%spread = init_spread_inventory
-         end if
-      end do
+      if (hlm_use_nocomp .eq. itrue) then
+         do pft = 1, numpft
+            if (EDPftvarcon_inst%initd_nocomp(pft) < 0.0_r8) then   
+               site_in%spread = init_spread_inventory
+            end if
+         end do
+      end if
 
-      
       ! Manage interactions of fixed biogeog (site level filter) and nocomp (patch level filter)
       ! Need to cover all potential biogeog x nocomp combinations
       ! 1. biogeog = false. nocomp = false: all PFTs on (DEFAULT)
@@ -1186,24 +1187,61 @@ contains
                end select phen_select
             end if if_spmode 
 
-            ! If positive EDPftvarcon_inst%initd is interpreted as initial recruit density.
-            ! If negative EDPftvarcon_inst%initd is interpreted as initial dbh. 
-            ! Dbh-initialization can only be used in nocomp mode.
+            ! If we are not in nocomp mode, then EDPftvarcon_inst%initd_fullfates is initial recruit density.
+            ! If we are in no comp mode, then a positive EDPftvarcon_inst%initd_nocomp is interpreted as initial recruit density.
+            ! If negative, EDPftvarcon_inst%initd_nocomp is interpreted as initial dbh. 
             ! In the dbh-initialization case, we calculate crown area for a single tree and then calculate
-            ! the density of plants  needed for a full canopy. 
-            if_init_dens: if (EDPftvarcon_inst%initd(pft) > nearzero) then  ! interpret as initial density and calculate diameter
+            ! the density of plants  needed for a full canopy.
 
-               cohort_n = EDPftvarcon_inst%initd(pft)*patch_in%area
-               if (hlm_use_nocomp .eq. itrue) then !in nocomp mode we only have one PFT per patch
+            if_fullfates: if (hlm_use_nocomp .eq. ifalse) then
+
+               cohort_n = EDPftvarcon_inst%initd_fullfates(pft)*patch_in%area
+               height = EDPftvarcon_inst%hgt_min(pft)
+
+               ! calculate the plant diameter from height
+               call h2d_allom(height, pft, dbh)
+
+            else ! We are in a nocomp simulation 
+
+               ! interpret as initial density and calculate diameter
+               if_init_dens: if (EDPftvarcon_inst%initd_nocomp(pft) > nearzero) then  
+
+                  cohort_n = EDPftvarcon_inst%initd_nocomp(pft)*patch_in%area
+                  ! in nocomp mode we only have one PFT per patch
                   ! as opposed to numpft's. So we should up the initial density
                   ! to compensate (otherwise runs are very hard to compare)
                   ! this multiplies it by the number of PFTs there would have been in
                   ! the single shared patch in competition mode.
                   ! n.b. that this is the same as currentcohort%n = %initd(pft) &AREA
                   cohort_n = cohort_n*sum(site_in%use_this_pft)
-               endif
-               height = EDPftvarcon_inst%hgt_min(pft)
 
+                  height = EDPftvarcon_inst%hgt_min(pft)
+
+                  ! calculate the plant diameter from height
+                  call h2d_allom(height, pft, dbh)
+
+               else ! interpret as initial diameter and calculate density 
+
+                  dbh = abs(EDPftvarcon_inst%initd_nocomp(pft))
+
+                  ! calculate crown area of a single plant
+                  call carea_allom(dbh, 1.0_r8, init_spread_inventory, pft, crown_damage,  &
+                       c_area)
+
+                  ! calculate initial density required to close canopy 
+                  cohort_n = patch_in%area/c_area
+
+                  ! calculate crown area of the cohort
+                  call carea_allom(dbh, cohort_n, init_spread_inventory, pft, crown_damage, &
+                       c_area)
+
+                  ! calculate height from diameter
+                  call h_allom(dbh, pft, height)
+
+               endif if_init_dens
+
+               ! If we are in SP mode we ignore the initial values and read in height,
+               ! which is used to calcualte n.
                ! h, dbh, leafc, n from SP values or from small initial size
                if (hlm_use_sp .eq. itrue) then
                   ! At this point, we do not know the bc_in values of tlai tsai and htop,
@@ -1211,47 +1249,16 @@ contains
                   ! Not sure if there's a way around this or not.
                   height = 0.5_r8
                   call calculate_SP_properties(height, 0.2_r8, 0.1_r8,         &
-                     patch_in%area, pft, crown_damage, 1,                      &
-                     EDPftvarcon_inst%vcmax25top(pft, 1), c_leaf, dbh,         &
-                     cohort_n, c_area)
-               else
-                  ! calculate the plant diameter from height
-                  call h2d_allom(height, pft, dbh)
-
-                  ! Calculate the leaf biomass from allometry
-                  ! (calculates a maximum first, then applies canopy trim)
-                  call bleaf(dbh, pft, crown_damage, canopy_trim, efleaf_coh, c_leaf)
+                       patch_in%area, pft, crown_damage, 1,                      &
+                       EDPftvarcon_inst%vcmax25top(pft, 1), c_leaf, dbh,         &
+                       cohort_n, c_area)
                endif  ! sp mode
 
-            else ! interpret as initial diameter and calculate density 
-               if (hlm_use_nocomp .eq. itrue) then
-                  
-                  dbh = abs(EDPftvarcon_inst%initd(pft))
+            endif if_fullfates
 
-                  ! calculate crown area of a single plant
-                  call carea_allom(dbh, 1.0_r8, init_spread_inventory, pft, crown_damage,       &
-                  c_area)
-
-                  ! calculate initial density required to close canopy 
-                  cohort_n = patch_in%area/c_area
-
-                  ! Calculate the leaf biomass from allometry
-                  ! (calculates a maximum first, then applies canopy trim)
-                  call bleaf(dbh, pft, crown_damage, canopy_trim, efleaf_coh,  &
-                       c_leaf)
-
-                  ! calculate crown area of the cohort
-                  call carea_allom(dbh, cohort_n, init_spread_inventory, pft, crown_damage,       &
-                       c_area)
-
-                  ! calculate height from diameter
-                  call h_allom(dbh, pft, height)
- 
-               else
-                  write(fates_log(),*) 'Negative fates_recruit_init_density can only be used in no comp mode'
-                  call endrun(msg=errMsg(sourcefile, __LINE__))
-               endif
-            endif if_init_dens 
+            ! Calculate the leaf biomass from allometry
+            ! (calculates a maximum first, then applies canopy trim)
+            call bleaf(dbh, pft, crown_damage, canopy_trim, efleaf_coh, c_leaf)
 
             ! calculate total above-ground biomass from allometry
             call bagw_allom(dbh, pft, crown_damage, efstem_coh, c_agw)

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -57,8 +57,10 @@ module EDPftvarcon
      real(r8), allocatable :: displar(:)             ! ratio of displacement height to canopy top height
      real(r8), allocatable :: bark_scaler(:)         ! scaler from dbh to bark thickness. For fire model.
      real(r8), allocatable :: crown_kill(:)          ! scaler on fire death. For fire model.
-     real(r8), allocatable :: initd(:)               ! initial seedling density
-
+     real(r8), allocatable :: initd_fullfates(:)     ! initial seedling density for runs
+                                                     ! with competition on (i.e. not nocomp)
+     real(r8), allocatable :: initd_nocomp(:)        ! either initial seedling density or initial
+                                                     ! plant size for nocomp runs
      real(r8), allocatable :: seed_suppl(:)          ! seeds that come from outside the gridbox.
 
      real(r8), allocatable :: lf_flab(:)             ! Leaf litter labile fraction [-]
@@ -382,7 +384,11 @@ contains
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
-    name = 'fates_recruit_init_density'
+    name = 'fates_recruit_init_density_full_fates'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_recruit_init_nocomp'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
@@ -799,9 +805,13 @@ contains
     call fates_params%RetrieveParameterAllocate(name=name, &
          data=this%crown_kill)
 
-    name = 'fates_recruit_init_density'
+    name = 'fates_recruit_init_density_full_fates'
     call fates_params%RetrieveParameterAllocate(name=name, &
-         data=this%initd)
+         data=this%initd_fullfates)
+
+    name = 'fates_recruit_init_nocomp'
+    call fates_params%RetrieveParameterAllocate(name=name, &
+         data=this%initd_nocomp)
 
     name = 'fates_recruit_seed_supplement'
     call fates_params%RetrieveParameterAllocate(name=name, &
@@ -1581,7 +1591,7 @@ contains
 
      integer :: npft,ipft
 
-     npft = size(EDPftvarcon_inst%initd,1)
+     npft = size(EDPftvarcon_inst%initd_fullfates,1)
 
      if(debug_report .and. is_master) then
 
@@ -1600,7 +1610,8 @@ contains
         write(fates_log(),fmt0) 'displar = ',EDPftvarcon_inst%displar
         write(fates_log(),fmt0) 'bark_scaler = ',EDPftvarcon_inst%bark_scaler
         write(fates_log(),fmt0) 'crown_kill = ',EDPftvarcon_inst%crown_kill
-        write(fates_log(),fmt0) 'initd = ',EDPftvarcon_inst%initd
+        write(fates_log(),fmt0) 'initd_fullfates = ',EDPftvarcon_inst%initd_fullfates
+        write(fates_log(),fmt0) 'initd_nocomp = ',EDPftvarcon_inst%initd_nocomp
         write(fates_log(),fmt0) 'seed_suppl = ',EDPftvarcon_inst%seed_suppl
         write(fates_log(),fmt0) 'lf_flab = ',EDPftvarcon_inst%lf_flab
         write(fates_log(),fmt0) 'lf_fcel = ',EDPftvarcon_inst%lf_fcel
@@ -2021,12 +2032,12 @@ contains
         !-----------------------------------------------------------------------------------
         
         if ( hlm_use_inventory_init == ifalse .and. & 
-             abs( EDPftvarcon_inst%initd(ipft) ) < nearzero ) then
+             abs( EDPftvarcon_inst%initd_fullfates(ipft) ) < nearzero ) then
           
            write(fates_log(),*) ' In a cold start run initial density cannot be zero.'
            write(fates_log(),*) ' For a bare ground run set to initial recruit density.'
            write(fates_log(),*) ' If no-comp is on it is possible to initialize with larger  '
-           write(fates_log(),*) ' plants by setting fates_recruit_init_density to a negative number'
+           write(fates_log(),*) ' plants by setting fates_recruit_init_nocomp to a negative number'
            write(fates_log(),*) ' which will be interpreted as (absolute) initial dbh. '
            write(fates_log(),*) ' Aborting'
            call endrun(msg=errMsg(sourcefile, __LINE__))

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -549,9 +549,12 @@ variables:
 	double fates_recruit_height_min(fates_pft) ;
 		fates_recruit_height_min:units = "m" ;
 		fates_recruit_height_min:long_name = "the minimum height (ie starting height) of a newly recruited plant" ;
-	double fates_recruit_init_density(fates_pft) ;
-		fates_recruit_init_density:units = "stems/m2" ;
-		fates_recruit_init_density:long_name = "initial seedling density for a cold-start near-bare-ground simulation. If negative sets initial tree dbh - only to be used in nocomp mode" ;
+	double fates_recruit_init_density_full_fates(fates_pft) ;
+		fates_recruit_init_density_full_fates:units = "stems/m2" ;
+		fates_recruit_init_density_full_fates:long_name = "initial seedling density for a cold-start near-bare-ground simulation in full fates (with competition)" ;
+	double fates_recruit_init_nocomp(fates_pft) ;
+		fates_recruit_init_nocomp:units = "stems/m2 or dbh cm" ;
+		fates_recruit_init_nocomp:long_name = "initial seedling density or initial size of seedlings (if negative) in nocomp mode" ;
 	double fates_recruit_prescribed_rate(fates_pft) ;
 		fates_recruit_prescribed_rate:units = "n/yr" ;
 		fates_recruit_prescribed_rate:long_name = "recruitment rate for prescribed physiology mode" ;
@@ -1534,7 +1537,11 @@ data:
  fates_recruit_height_min = 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 0.2, 0.2, 0.2, 0.8, 
     0.8, 0.11, 0.2, 0.2 ;
 
- fates_recruit_init_density = 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 5, 2, 2 ;
+ fates_recruit_init_density_full_fates = 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
+    0.2, 0.2, 0.16, 0.2, 0.2, 0.2, 0.2 ;
+
+ fates_recruit_init_nocomp =  -10, -10, -10, -10, -10, -10, -1, -1, -1,
+    -1, -1, -0.5, -0.5, -0.5 ;
 
  fates_recruit_prescribed_rate = 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 
     0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02 ;


### PR DESCRIPTION
### Description:
This PR splits the existing init_density parameter in two. One is used for full fates runs - values must be positive and correspond to the initial vegetation density (stems per area). The other is used for nocomp runs - values can be positive or negative. Positive values set initial stem density, negative values are interpreted as (absolute) diameter values. This change allows us to keep the option of dbh or density initialisation for nocomp runs, while not breaking full fates runs if we have negative values in the default parameter file. 

### Collaborators:
@rosiealice @mvdebolskiy @kjetilaas

### Expectation of Answer Changes:
Should be bfb if parameter values don't change. Although the current values need to be updated based on @rosiealice 's tests. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Branched from sci.1.85.1_api.40.0.0_noresm_v6, run with ctsm5.3.045_noresm_v13. 

Nocomp runs look as expected. I haven't tested full fates.  

<img width="576" height="546" alt="image" src="https://github.com/user-attachments/assets/2b408de2-0393-4c18-a011-f9f28ad004f4" />

Above is the first month for two nocomp runs with top panel setting initial density to 0.2 plants m-2 and bottom panel setting initial plant diameter to 20cm for trees, 2cm for shrubs and 0.5cm for grasses. 
