### PR TITLE
Bug fix to land use calculation of secondary young fraction 

### DIFF
--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -814,7 +814,7 @@ contains
      currentPatch => this%oldest_patch
      do while (associated(currentPatch))
         if (currentPatch%land_use_label .eq. secondaryland) then
-           if ( currentPatch%age .ge. secondary_age_threshold ) then
+           if ( currentPatch%age_since_anthro_disturbance .ge. secondary_age_threshold ) then
               secondary_old_area = secondary_old_area + currentPatch%area
            else
               secondary_young_area = secondary_young_area + currentPatch%area


### PR DESCRIPTION
### Description:
This change addresses issue [1478](https://github.com/NGEET/fates/issues/1478). Since get_harvest_rate_area is using patch age_since_anthro_disturbance to determine if patches are over the threshold to count as secondary old, the function get_secondary_young_frac also needs to use age_since_anthro_disturbance and not patch age, otherwise the secondary young frac can be 1, but some patches are over the threshold to count as secondary old, triggering 100% harvest. 

### Collaborators:
@kjetilaas @rosiealice 

### Expectation of Answer Changes:
This will be answer changing if land use is on. It should prevent large jumps in harvest rate. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Quick test on a branch from tag: sci.1.85.1_api.40.0.0_noresm_v4 (to allow testing with a spun up case) compiled and ran and seemed to fix the issue. 

