### PR TITLE
Comment out endrun from canopy resistance bug

### DIFF
--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -1114,7 +1114,7 @@ contains
                            write(fates_log(),*) 'its boundary layer resistance component'
                            write(fates_log(),*) 'r_sb_leaves [s/m]: ',r_sb_leaves
                            write(fates_log(),*) 'bc_in(s)%rb_pa(ifp) [s/m]: ',bc_in(s)%rb_pa(ifp)
-                           call endrun(msg=errMsg(sourcefile, __LINE__))
+!                           call endrun(msg=errMsg(sourcefile, __LINE__))
                         end if
                         
                         ! Mean leaf stomatal resistance for all patch leaves


### PR DESCRIPTION
This PR comments out an endrun triggered when combined canopy resistance is smaller than boundary layer resistance. 
Ongoing issue here: https://github.com/NGEET/fates/issues/1487
This needs to be fixed at some point, this is a stopgap measure to allow us to run simulations while we investigate further. Bug only seems to occur in arctic shrubs. 

### Collaborators:
@rosiealice @maritsandstad 

### Expectation of Answer Changes:
Answer changing - will prevent model crashes. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

