### PR TITLE
Silence nocomp patch fusion warning

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -3368,11 +3368,11 @@ contains
                 endif
              end do
 
-             if ( .not. gotfused ) then
-                !! somehow didn't find a patch to fuse with.
-                write(fates_log(),*) 'Warning. small nocomp patch wasnt able to find another patch to fuse with.', &
-                     currentPatch%nocomp_pft_label, currentPatch%land_use_label, currentPatch%area
-             endif
+             ! if ( .not. gotfused ) then
+             !    !! somehow didn't find a patch to fuse with.
+             !    write(fates_log(),*) 'Warning. small nocomp patch wasnt able to find another patch to fuse with.', &
+             !         currentPatch%nocomp_pft_label, currentPatch%land_use_label, currentPatch%area
+             ! endif
 
           else nocomp_if
 


### PR DESCRIPTION
### Description:
Comment out a warning about patch fusion of nocomp patches that fills up the log file when land use is on. 


### Collaborators:
@maritsandstad @rosiealice @kjetilaas 

### Expectation of Answer Changes:
Should not change answers - just stops the lnd.log file being enormous. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Not tested
