### PR TITLE
Add 95th height history variable

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -306,7 +306,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_seedling_pool_si        ! carbon only
   integer :: ih_ba_weighted_height_si
   integer :: ih_ca_weighted_height_si
-  integer :: ih_patch_weighted_95hpctile_height_si
+  integer :: ih_patch_weighted_95thpctile_height_si
   integer :: ih_seeds_in_local_elem
   integer :: ih_seeds_in_extern_elem
   integer :: ih_seed_decay_elem

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -306,6 +306,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_seedling_pool_si        ! carbon only
   integer :: ih_ba_weighted_height_si
   integer :: ih_ca_weighted_height_si
+  integer :: ih_patch_weighted_95hpctile_height_si
   integer :: ih_seeds_in_local_elem
   integer :: ih_seeds_in_extern_elem
   integer :: ih_seed_decay_elem
@@ -2413,6 +2414,7 @@ contains
     real(r8) :: leaf_herbivory     ! mass of leaves eaten by herbivores [kg/yr]
     real(r8) :: n_perm2            ! abundance per m2
     real(r8) :: patch_fracarea  ! Fraction of area for this patch
+    real(r8) :: crown_area_covered ! accumulator variable for patch crown area
     
     associate( hio_npatches_si         => this%hvars(ih_npatches_si)%r81d, &
          hio_ncohorts_si         => this%hvars(ih_ncohorts_si)%r81d, &
@@ -2424,6 +2426,7 @@ contains
          hio_fates_fraction_si   => this%hvars(ih_fates_fraction_si)%r81d, &
          hio_ba_weighted_height_si  => this%hvars(ih_ba_weighted_height_si)%r81d, &
          hio_ca_weighted_height_si  => this%hvars(ih_ca_weighted_height_si)%r81d, &
+         hio_patch_weighted_95thpctile_height_si  => this%hvars(ih_patch_weighted_95thpctile_height_si)%r81d, &
          hio_canopy_spread_si    => this%hvars(ih_canopy_spread_si)%r81d, &
          hio_nesterov_fire_danger_si => this%hvars(ih_nesterov_fire_danger_si)%r81d, &
          hio_fire_nignitions_si => this%hvars(ih_fire_nignitions_si)%r81d, &
@@ -2953,6 +2956,26 @@ contains
 
                ccohort => ccohort%taller
             enddo cohortloop ! cohort loop
+
+            
+            ! mean 95th percentile height. loop through cohorts on patch again, this time from tallest to shortest
+            crown_area_covered = 0._r8
+            ccohort => cpatch%tallest
+            do while(associated(ccohort))
+               if (ccohort%canopy_layer .eq. 1) then ! ignore anything not in the canopy
+                  if (((ccohort%c_area + crown_area_covered)/cpatch%area) .ge. 0.05_r8 ) then
+                     hio_patch_weighted_95thpctile_height_si(io_si) = &
+                          hio_patch_weighted_95thpctile_height_si(io_si) + ccohort%height * cpatch%area/AREA
+                     ccohort => null() ! exit the cohort loop
+                  else
+                     crown_area_covered = crown_area_covered + ccohort%c_area
+                     ccohort => ccohort%shorter
+                  endif
+               else
+                  ccohort => ccohort%shorter
+               endif
+            enddo  ! cohort loop
+
 
             cpatch => cpatch%younger
          end do patchloop !patch loop
@@ -6303,6 +6326,12 @@ contains
             avgflag='A', vtype=site_r8, hlms='CLM:ALM',                           &
             upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
             index=ih_ca_weighted_height_si)
+
+       call this%set_history_var(vname='FATES_MEAN_95PCTILE_HEIGHT', units='m',        &
+            long='The patch-area-weighted mean of 95th percentile height of canopy plants within a given patch', use_default='active', &
+            avgflag='A', vtype=site_r8, hlms='CLM:ALM',                           &
+            upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
+            index=ih_patch_weighted_95thpctile_height_si)
 
        call this%set_history_var(vname='FATES_COLD_STATUS', units='',             &
             long='site-level cold status, 0=not cold-dec, 1=too cold for leaves, 2=not too cold',  &


### PR DESCRIPTION
### Description:
This PR adds a history variable that calculates a gridcell-level height that is the average across all patchs of the 95th percentile height. This allows us to compare with GEDI and other spaceborne or airborne lidar-derived metrics. Changes are from PR #1485 on the NGEET repo: https://github.com/NGEET/fates/pull/1485. It would be useful if we had these on the NorESM side for current calibration efforts. 


### Collaborators:
@rosiealice 

### Expectation of Answer Changes:
Should not change science - only adds a FATES history variable. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Compiles 