### PR TITLE
Remove 'nevercold' logic

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -946,6 +946,7 @@ contains
     integer  :: ncdstart          ! beginning of counting period for chilling degree days.
     integer  :: gddstart          ! beginning of counting period for growing degree days.
     integer  :: nlevroot          ! Number of rooting levels to consider
+    integer :: nchill_threshold  ! how many days of below zero weather do we need to allow cold dec buburst 
     real(r8) :: temp_in_C         ! daily averaged temperature in celsius
     real(r8) :: temp_wgt          ! canopy area weighting factor for daily average
                                   ! vegetation temperature calculation
@@ -1118,11 +1119,19 @@ contains
     !   this prevents tropical or warm climate plants that are "cold-deciduous"
     !   from ever re-flushing after they have reached their maximum age (thus
     !   preventing them from competing
-
+    
+    ! if fixed biogeography is on, we don't have an nchill threshold logic, because
+    ! we are only growing cold deciduous trees where they are in real life
+    if(hlm_use_fixed_biogeog .eq. ifalse)then
+       nchill_threshold=1
+    else
+       nchill_threshold=0
+    endif
+    
     if ( any(currentSite%cstatus == [phen_cstat_iscold,phen_cstat_nevercold]) .and. &
          (currentSite%grow_deg_days > gdd_threshold) .and. &
          (currentSite%cndaysleafoff > ED_val_phen_mindayson) .and. &
-         (currentSite%nchilldays >= 1)) then
+         (currentSite%nchilldays >= nchill_threshold)) then
        currentSite%cstatus = phen_cstat_notcold  ! Set to not-cold status (leaves can come on)
        currentSite%cleafondate = model_day_int
        currentSite%cndaysleafon = 0
@@ -1169,7 +1178,7 @@ contains
                                                   ! when there is no 'off' period.
        currentSite%grow_deg_days  = 0._r8
 
-       currentSite%cstatus = phen_cstat_nevercold  ! alter status of site to imply that this
+       currentSite%cstatus = phen_cstat_iscold  ! alter status of site to imply that this
        ! site is never really cold enough
        ! for cold deciduous
        currentSite%cleafoffdate = model_day_int    ! record leaf off date


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
This PR removes the 'nevercold' logic when fixed biogeog is on and fixes the issue with BDTs dying in CPLHIST mode. More details on testing to follow... 


### Description:
This makes the threshold for leaf on '0 ' for fixed biogeography runs, and still '1' for full fates runs. This logic on chilling days largely exists to prevent BCDs from growing in the tropics, and therefore is not needed in fixed biogeog mode. 

At the moment, I have removed the capacity entirely for the plants to enter 'nevercold' mode. This is because there is no way out of nevercold mode, so for places where there is an occasional warm winter, we are stuck there forever. I think that 1) this feature needs to be reassessed if we use it operationally in full fates and 2) we still need one cold day in full fates to have leaf flush, so the plants will still die in the absence of the 'nevercold' mode.

If we adopt this logic in the main FATES code we would likely want to remove the whole 'nevercold' functionality. This is a fix to an urgent problem and so I have made it almost as unintrusive as I can for now. 

### Collaborators:

### Expectation of Answer Changes:
Answers will change for cold deciduous plants. Specifically where there are not any chillling days in the winter. 

The primary motivation for this was encountering one year in the CPLHIST that did not have any <0 days in the Eastern US. This triggered the vegetation to enter 'nevercold' state, from which there is, at present, no return. 

This is the output for this site (the third column) WITHOUT the changes. 
<img width="3500" height="2500" alt="image" src="https://github.com/user-attachments/assets/fe8ab560-4eba-4560-a241-2b0814c975db" />

and this is the output WITH these changes. 
<img width="3500" height="2500" alt="image" src="https://github.com/user-attachments/assets/d7349ab3-7717-41c5-9844-3d1f81886b2c" />

(both of these runs use
````
DATM_YR_START: 335
````
to trigger the particular year which causes this behaviour. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

