### PR TITLE
Clear vegetation during transition to rangeland

### DIFF
--- a/biogeochem/FatesLandUseChangeMod.F90
+++ b/biogeochem/FatesLandUseChangeMod.F90
@@ -182,7 +182,7 @@ contains
     
     ! default value of ruleset 4 above means that plants are not cleared during land use change
     ! transitions to rangeland, whereas plants are cleared in transitions to pasturelands and croplands.
-    integer, parameter    :: ruleset = 4   ! ruleset to apply from table 1 of Ma et al (2020)
+    integer, parameter    :: ruleset = 1   ! ruleset to apply from table 1 of Ma et al (2020)
     ! https://doi.org/10.5194/gmd-13-3203-2020
 
     ! clearing matrix applies from the donor to the receiver land use type of the newly-transferred


### PR DESCRIPTION
### Description:
This PR changes the land use logic ruleset so that vegetation is cleared when land use classes change from primary or secondary land to rangeland. This results in better alignment with global veg C products. 

### Collaborators:
@kjetilaas @rosiealice 

### Expectation of Answer Changes:
This should not be answer changing in simulations with steady state land use (i.e. spin ups or 2000s runs). It will change answers in historic runs with time series of land use change. It will result in less vegetation in rangeland areas. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Not tested with the most recent tag. Previous runs from sci.1.85.1_api.40.0.0_nor_sci2_api1 comparing to the default are here: 


With clearing (this PR): 
<img width="3000" height="1000" alt="image" src="https://github.com/user-attachments/assets/e1d62007-8e1c-4737-bd92-4d7fa5ef6635" />


Without clearing (current default): 
<img width="3000" height="1000" alt="image" src="https://github.com/user-attachments/assets/c380efe8-b793-42e3-bb1e-17752bc5c7e8" />
