### PR TITLE
Update hydraulic failure mortality cflux history name to match NGEET repo

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -7802,7 +7802,7 @@ contains
                upfreq=group_dyna_complx, ivar=ivar, initialize=initialize_variables,                 &
                index=ih_mortality_carbonflux_si_pft)
 
-          call this%set_history_var(vname='FATES_MORTALITY_HYDRAULIC_CFLUX_PF', units='kg m-2 s-1',    &
+          call this%set_history_var(vname='FATES_MORTALITY_HYDRO_CFLUX_PF', units='kg m-2 s-1',    &
                long='PFT-level flux of biomass carbon from live to dead pool from hydraulic failure mortalityy', &
                use_default='active', avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', &
                upfreq=group_dyna_complx, ivar=ivar, initialize=initialize_variables,                 &


### PR DESCRIPTION
### Description:
Hydraulic failure mortality carbon flux has a different name in NorESM-FATES than on the NGEET repo which keeps tripping me up. 

See NGEET: https://github.com/NGEET/fates/blob/55ec6c7768061148fc107a0810d3690763d85320/main/FatesHistoryInterfaceMod.F90#L7791

And NorESM-FATES: https://github.com/NorESMhub/fates/blob/82e7c0bbf23b64c239924b705fd630ce7237580c/main/FatesHistoryInterfaceMod.F90#L7805

This PR changes NorESM side to match NGEET. 

### Collaborators:

### Expectation of Answer Changes:
Not answer changing but will require possible scripting updates if this history variable is being manually added to runs. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Not tested. 