### PR TITLE
Taking out option that sets vcmax25top etc to zero in the case of no …

### DIFF
--- a/biogeochem/FatesCohortMod.F90
+++ b/biogeochem/FatesCohortMod.F90
@@ -979,20 +979,21 @@ module FatesCohortMod
 
         this%kp25top = sum(param_derived%kp25top(ipft, 1:nleafage)*            &
           frac_leaf_aclass(1:nleafage))
-
-      else if (hlm_use_sp .eq. itrue) then
+      
+      ! This else branch used to only be the behaviour in sp-mode
+      ! if the if-statement was skipped because of no leaves in any
+      ! of the age classes, all variables were instead set to zero
+      ! which caused a restart bug and non b4b in certain spun-up cases
+      ! Therefore we choose the behaviour which sets these variables to
+      ! the values for the first leaf age_class
+      ! If leaf_ageclasses come into active use, this issue might need 
+      ! to be revisited
+      else
           
         this%vcmax25top = EDPftvarcon_inst%vcmax25top(ipft, 1)
         this%jmax25top = param_derived%jmax25top(ipft, 1)
         this%tpu25top = param_derived%tpu25top(ipft, 1)
         this%kp25top = param_derived%kp25top(ipft, 1)
-
-      else
-      
-        this%vcmax25top = 0._r8
-        this%jmax25top  = 0._r8
-        this%tpu25top   = 0._r8
-        this%kp25top    = 0._r8
 
       end if
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

Attempted solution to the restart bug described and investigated here: 
https://github.com/NorESMhub/NorESM/issues/770
and here:
https://github.com/NorESMhub/CTSM/issues/200 

The issue was tracked down to an inconsistent value of vcmax25top in a  cohort with no leaves at restart, for which vcmax25top was set to 0 in the restart case, but not in the initialisation case. This happened in UpdateCohortBioPhysRates in FatesCohortMod where the array of leaves at different age classes frac_leaf_aclass was zero.

In this PR we change that behaviour, so that in the case of no leaves, the value for vcmax25top is set to the value it has in the first age-class and similarly for all the other cohort biophysical rates set in this method. This is the same as  the behaviour for all cohorts in SP-mode, so the change was performed by collapsing an else is then, else branch into a single else using the sp_mode behaviour.


### Collaborators:
<!--- List names of collaborators or people who have interacted -->
Primarily the work of @mvertens, 

@mvdebolskiy @rgknox @rosiealice have all contributed significantly to figuring this, personally I am mainly just setting up this PR.  

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
In a cohort with no leaves, UpdateCohortBioPhysRates will pull the rates from the first ageclass rather than setting them to zero.

We expect this to change answers only very marginally, especially since multiple leaf ageclasses are not in use, but hopefully enough to ensure b4b restarts. 

### Checklist

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

