### PR TITLE
Mirror of NGEET 1489 - land use clearing logic updates

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -782,9 +782,9 @@ contains
                                ! If we are clearing to make crops, then kill everything
                                if (i_landusechange_receiverpatchlabel .eq. cropland .or. &
                                     i_landusechange_receiverpatchlabel .eq. pastureland) then
-                                  clear_all = itrue
+                                  clear_all = .true.
                                else ! otherwise kill a fraction of the cohort determined by the clearing mortality param
-                                  clear_all = ifalse
+                                  clear_all = .false.
                                end if
                                
                                call landusechange_litter_fluxes(currentSite, currentPatch, &

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -780,7 +780,8 @@ contains
                                     newPatch, patch_site_areadis,bc_in)
                             case (dtype_ilandusechange)
                                ! If we are clearing to make crops, then kill everything
-                               if (i_landusechange_receiverpatchlabel .eq. cropland) then
+                               if (i_landusechange_receiverpatchlabel .eq. cropland .or. &
+                                    i_landusechange_receiverpatchlabel .eq. pastureland) then
                                   clear_all = itrue
                                else ! otherwise kill a fraction of the cohort determined by the clearing mortality param
                                   clear_all = ifalse
@@ -1317,7 +1318,8 @@ contains
                                   if ( clearing_matrix(i_donorpatch_landuse_type,i_landusechange_receiverpatchlabel) ) then
 
                                      ! If we are clearing for crops then kill everything 
-                                     if (i_landusechange_receiverpatchlabel == cropland ) then
+                                     if (i_landusechange_receiverpatchlabel == cropland .or. &
+                                          i_landusechange_receiverpathclabel == pasureland) then
                                         nc%n = 0._r8
                                      else
                                         ! Otherwise kill some proportion of the PFT based on the PFT-level clearing mortality parameter

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1319,7 +1319,7 @@ contains
 
                                      ! If we are clearing for crops then kill everything 
                                      if (i_landusechange_receiverpatchlabel == cropland .or. &
-                                          i_landusechange_receiverpathclabel == pasureland) then
+                                          i_landusechange_receiverpatchlabel == pastureland) then
                                         nc%n = 0._r8
                                      else
                                         ! Otherwise kill some proportion of the PFT based on the PFT-level clearing mortality parameter

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1323,7 +1323,7 @@ contains
                                         nc%n = 0._r8
                                      else
                                         ! Otherwise kill some proportion of the PFT based on the PFT-level clearing mortality parameter
-                                        nc%n = nc%n * EDPftvarcon_inst%landuse_clearing_mortality(currentCohort%pft)
+                                        nc%n = nc%n * (1.0_r8 - EDPftvarcon_inst%landuse_clearing_mortality(currentCohort%pft) )
                                      end if
 
                                   end if

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -780,7 +780,7 @@ contains
                                     newPatch, patch_site_areadis,bc_in)
                             case (dtype_ilandusechange)
                                ! If we are clearing to make crops, then kill everything
-                               if (i_landusechange_receiverpatchlabel .eq. end_receiver_lulabel) then
+                               if (i_landusechange_receiverpatchlabel .eq. cropland) then
                                   clear_all = itrue
                                else ! otherwise kill a fraction of the cohort determined by the clearing mortality param
                                   clear_all = ifalse
@@ -1316,10 +1316,8 @@ contains
                                   ! now apply survivorship based on the type of landuse transition
                                   if ( clearing_matrix(i_donorpatch_landuse_type,i_landusechange_receiverpatchlabel) ) then
 
-
-                                     ! If we are clearing for crops then kill everything
-                                     ! Note crops needs to be last lu class for this logic to work 
-                                     if (i_landusechange_receiverpatchlabel == end_receiver_lulabel ) then
+                                     ! If we are clearing for crops then kill everything 
+                                     if (i_landusechange_receiverpatchlabel == cropland ) then
                                         nc%n = 0._r8
                                      else
                                         ! Otherwise kill some proportion of the PFT based on the PFT-level clearing mortality parameter

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -559,6 +559,7 @@ contains
     integer  :: n_pfts_by_landuse
     integer  :: which_pft_allowed
     logical  :: buffer_patch_used
+    logical  :: clear_all
     !---------------------------------------------------------------------
 
     if (hlm_use_nocomp .eq. itrue) then
@@ -778,9 +779,17 @@ contains
                                call mortality_litter_fluxes(currentSite, currentPatch, &
                                     newPatch, patch_site_areadis,bc_in)
                             case (dtype_ilandusechange)
+                               ! If we are clearing to make crops, then kill everything
+                               if (i_landusechange_receiverpatchlabel .eq. end_receiver_lulabel) then
+                                  clear_all = itrue
+                               else ! otherwise kill a fraction of the cohort determined by the clearing mortality param
+                                  clear_all = ifalse
+                               end if
+                               
                                call landusechange_litter_fluxes(currentSite, currentPatch, &
                                     newPatch, patch_site_areadis,bc_in, &
-                                    clearing_matrix(i_donorpatch_landuse_type,i_landusechange_receiverpatchlabel))
+                                    clearing_matrix(i_donorpatch_landuse_type,i_landusechange_receiverpatchlabel), &
+                                    clear_all)
 
                                ! if land use change, then may need to change nocomp pft, so tag as having transitioned LU
                                newPatch%changed_landuse_this_ts = .true.
@@ -1306,8 +1315,17 @@ contains
 
                                   ! now apply survivorship based on the type of landuse transition
                                   if ( clearing_matrix(i_donorpatch_landuse_type,i_landusechange_receiverpatchlabel) ) then
-                                     ! kill everything
-                                     nc%n = 0._r8
+
+
+                                     ! If we are clearing for crops then kill everything
+                                     ! Note crops needs to be last lu class for this logic to work 
+                                     if (i_landusechange_receiverpatchlabel == end_receiver_lulabel ) then
+                                        nc%n = 0._r8
+                                     else
+                                        ! Otherwise kill some proportion of the PFT based on the PFT-level clearing mortality parameter
+                                        nc%n = nc%n * EDPftvarcon_inst%landuse_clearing_mortality(currentCohort%pft)
+                                     end if
+
                                   end if
 
                                case default
@@ -2621,12 +2639,15 @@ contains
 
   subroutine landusechange_litter_fluxes(currentSite, currentPatch, &
        newPatch, patch_site_areadis, bc_in,  &
-       clearing_matrix_element)
+       clearing_matrix_element, clear_all)
     !
     ! !DESCRIPTION:
     !  CWD pool from land use change.
     !  Carbon going from felled trees into CWD pool
-    !  Either kill everything or nothing on disturbed land, depending on clearing matrix
+    !  Whether or not to clear PFTs during transition from one land use class
+    !  to another is based on the clearing logic matrix. 
+    !  If clearing occurs, the fraction of the PFT killed depends on the
+    !  pft-level clearing mortality parameter
     !
     ! !USES:
     use SFParamsMod,          only : SF_VAL_CWD_FRAC
@@ -2638,7 +2659,8 @@ contains
     real(r8)               , intent(in)            :: patch_site_areadis ! Area being donated
     type(bc_in_type)       , intent(in)            :: bc_in
     logical                , intent(in)            :: clearing_matrix_element ! whether or not to clear vegetation
-
+    logical                , intent(in)            :: clear_all ! should all vegetation be killed - applies to crops
+    
     !
     ! !LOCAL VARIABLES:
 
@@ -2685,7 +2707,13 @@ contains
        if (hlm_use_planthydro == itrue) then
           currentCohort => currentPatch%shortest
           do while(associated(currentCohort))
-             num_dead_trees  = (currentCohort%n*patch_site_areadis/currentPatch%area)
+
+             if (clear_all) then
+                num_dead_trees = (currentCohort%n * patch_site_areadis/currentPatch%area)
+             else
+                num_dead_trees  = (currentCohort%n*patch_site_areadis/currentPatch%area) * &
+                     EDPftvarcon_inst%landuse_clearing_mortality(currentCohort%pft)
+             end if
              call AccumulateMortalityWaterStorage(currentSite,currentCohort,num_dead_trees)
              currentCohort => currentCohort%taller
           end do
@@ -2756,8 +2784,15 @@ contains
 
 
              ! Absolute number of dead trees being transfered in with the donated area
-             num_dead_trees = (currentCohort%n * &
-                  patch_site_areadis/currentPatch%area)
+
+             if (clear_all) then
+                num_dead_trees = (currentCohort%n * &
+                     patch_site_areadis/currentPatch%area)
+             else
+                num_dead_trees = (currentCohort%n * &
+                     patch_site_areadis/currentPatch%area) * &
+                     EDPftvarcon_inst%landuse_clearing_mortality(pft)
+             end if
 
              ! Contribution of dead trees to leaf litter
              donatable_mass = num_dead_trees * (leaf_m+repro_m) * &

--- a/biogeochem/FatesLandUseChangeMod.F90
+++ b/biogeochem/FatesLandUseChangeMod.F90
@@ -16,6 +16,7 @@ module FatesLandUseChangeMod
   use FatesInterfaceTypesMod    , only : hlm_num_luh2_states
   use FatesInterfaceTypesMod    , only : hlm_num_luh2_transitions
   use FatesInterfaceTypesMod    , only : hlm_use_potentialveg
+  use FatesInterfaceTypesMod    , only : hlm_lu_transition_logic 
   use FatesUtilsMod             , only : FindIndex
   use EDTypesMod                , only : area_site => area
 
@@ -178,13 +179,16 @@ contains
     ! the purpose of this is to define a ruleset for when to clear the vegetation in transitioning
     ! from one land use type to another
 
-    logical, intent(out) :: clearing_matrix(n_landuse_cats,n_landuse_cats)
     
-    ! default value of ruleset 4 above means that plants are not cleared during land use change
-    ! transitions to rangeland, whereas plants are cleared in transitions to pasturelands and croplands.
-    integer, parameter    :: ruleset = 1   ! ruleset to apply from table 1 of Ma et al (2020)
-    ! https://doi.org/10.5194/gmd-13-3203-2020
+    logical, intent(out) :: clearing_matrix(n_landuse_cats,n_landuse_cats)
 
+    ! local variables
+    integer :: ruleset
+    
+    ! ruleset to apply from table 1 of Ma et al (2020)
+    ! https://doi.org/10.5194/gmd-13-3203-2020
+    ruleset = hlm_lu_transition_logic
+    
     ! clearing matrix applies from the donor to the receiver land use type of the newly-transferred
     ! patch area values of clearing matrix: false => do not clear; true => clear
 

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -272,6 +272,9 @@ module EDPftvarcon
      ! dry deposition
      real(r8), allocatable :: wesley_pft_index_fordrydep(:)
 
+     ! Clearing mortality rate
+     real(r8), allocatable :: landuse_clearing_mortality(:) ! Fraction of cohort killed when patch is cleared during land use transitions
+     
    contains
      procedure, public :: Init => EDpftconInit
      procedure, public :: Register
@@ -759,6 +762,10 @@ contains
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
+        name = 'fates_landuse_clearing_mortality'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
     name = 'fates_dev_arbitrary_pft'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
           dimension_names=dim_names, lower_bounds=dim_lower_bound)
@@ -1206,6 +1213,10 @@ contains
     name = 'fates_landuse_grazing_palatability'
     call fates_params%RetrieveParameterAllocate(name=name, &
          data=this%landuse_grazing_palatability)
+
+    name = 'fates_landuse_clearing_mortality'
+    call fates_params%RetrieveParameterAllocate(name=name, &
+         data=this%landuse_clearing_mortality)
 
   end subroutine Receive_PFT
 

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1516,6 +1516,7 @@ contains
          hlm_num_lu_harvest_cats   = unset_int
          hlm_num_luh2_states       = unset_int
          hlm_num_luh2_transitions  = unset_int
+         hlm_lu_transition_logic = unset_int
          hlm_use_cohort_age_tracking = unset_int
          lb_params%dayl_switch = unset_int
          lb_params%photo_tempsens_model = unset_int
@@ -2047,7 +2048,13 @@ contains
                if (fates_global_verbose()) then
                   write(fates_log(),*) 'Transfering hlm_num_luh2_transitions= ',ival,' to FATES'
                end if
-
+               
+            case('fates_lu_transition_logic')
+               hlm_lu_transition_logic = ival
+               if (fates_global_verbose()) then
+                  write(fates_log(),*) 'Transfering hlm_lu_transition_logic= ',ival,' to FATES'
+               end if
+               
             case('use_cohort_age_tracking')
                hlm_use_cohort_age_tracking = ival
                if (fates_global_verbose()) then

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -111,6 +111,10 @@ module FatesInterfaceTypesMod
                                                          ! If 1, it automatically sets
                                                          ! hlm_use_logging to 1
 
+   integer, public :: hlm_lu_transition_logic    ! This flag signals which logic to use in transitions between land use classes
+                                                 ! See the FATES user guide for full description of options
+   
+
    integer, public :: hlm_num_lu_harvest_cats    ! number of hlm harvest categories (e.g. primary forest harvest, secondary young forest harvest, etc.)
                                                          ! this is the first dimension of:
                                                          ! harvest_rates in dynHarvestMod

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -353,7 +353,7 @@ variables:
 		fates_landuse_grazing_palatability:long_name = "Relative intensity of leaf grazing/browsing per PFT" ;	
 	double fates_landuse_clearing_mortality(fates_pft) ;
 		fates_landuse_clearing_mortality:units = "fraction" ;
-		fates_landuse_clearing_mortality:long_name = "Fraction of cohort killed during land use clearing" ;
+		fates_landuse_clearing_mortality:long_name = "Fraction of PFT killed during land use clearing to rangeland" ;
 	double fates_landuse_harvest_pprod10(fates_pft) ;
 		fates_landuse_harvest_pprod10:units = "fraction" ;
 		fates_landuse_harvest_pprod10:long_name = "fraction of harvest wood product that goes to 10-year product pool (remainder goes to 100-year pool)" ;
@@ -1382,7 +1382,7 @@ data:
  fates_landuse_grazing_palatability = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.3, 1, 1, 
     1, 1 ;
 
- fates_landuse_clearing_mortality = 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 1, 1, 1, 1, 1, 1, 1, 1 ;	
+ fates_landuse_clearing_mortality = 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0, 0, 0, 0, 0, 0, 0, 0 ;	
 
  fates_landuse_harvest_pprod10 = 1, 0.75, 0.75, 0.75, 1, 0.75, 1, 1, 1, 1, 1, 
     1, 1, 1 ;

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -350,7 +350,10 @@ variables:
 		fates_hydro_vg_n_node:long_name = "(used if hydr_htftype_node = 2),n in van Genuchten 1980 model, pore size distribution parameter" ;
 	double fates_landuse_grazing_palatability(fates_pft) ;
 		fates_landuse_grazing_palatability:units = "unitless 0-1" ;
-		fates_landuse_grazing_palatability:long_name = "Relative intensity of leaf grazing/browsing per PFT" ;
+		fates_landuse_grazing_palatability:long_name = "Relative intensity of leaf grazing/browsing per PFT" ;	
+	double fates_landuse_clearing_mortality(fates_pft) ;
+		fates_landuse_clearing_mortality:units = "fraction" ;
+		fates_landuse_clearing_mortality:long_name = "Fraction of cohort killed during land use clearing" ;
 	double fates_landuse_harvest_pprod10(fates_pft) ;
 		fates_landuse_harvest_pprod10:units = "fraction" ;
 		fates_landuse_harvest_pprod10:long_name = "fraction of harvest wood product that goes to 10-year product pool (remainder goes to 100-year pool)" ;
@@ -1378,6 +1381,8 @@ data:
 
  fates_landuse_grazing_palatability = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.3, 1, 1, 
     1, 1 ;
+
+ fates_landuse_clearing_mortality = 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 1, 1, 1, 1, 1, 1, 1, 1 ;	
 
  fates_landuse_harvest_pprod10 = 1, 0.75, 0.75, 0.75, 1, 0.75, 1, 1, 1, 1, 1, 
     1, 1, 1 ;


### PR DESCRIPTION
This PR is a mirror of the NGEET side 1489 https://github.com/NGEET/fates/pull/1489. 
It goes with NorESM-CTSM side PR 211 (https://github.com/NorESMhub/CTSM/pull/211)

It adds a new parameter that controls the fraction of PFTs killed when converting to rangeland. It also converts the hard coded value controlling clearing logic into a namelist option. 

Compiles on Betzy. I'll run a 100 year 2000s steady state run to check it doesn't do anything unexpected. 