### PR TITLE
Update clearing mortality parameter

### DIFF
--- a/parameter_files/fates_params_noresm.json
+++ b/parameter_files/fates_params_noresm.json
@@ -688,7 +688,7 @@
       "dims": ["fates_pft"],
       "long_name": "Fraction of PFT killed during land use clearing to rangeland",
       "units": "fraction",
-      "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      "data": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     },
     "fates_landuse_harvest_pprod10":{
       "dtype": "float",


### PR DESCRIPTION
### Description:
This parameter controls the fraction of a PFT that is killed when converting forest to rangeland (if rangeland clearing is on per the namelist option). To follow logic from Ma et al. we want to kill trees but not shrubs and grasses, and so this parameter should be 1.0 for tree PFTs and 0 otherwise. 

Sorry to have missed this in the update to ngeet PR. 

Noting this only impacts runs with transient land use on - it will not impact spinups with constant land use. 



### Collaborators:
@kjetilaas @rosiealice 

### Expectation of Answer Changes:
This will increase land use change emissions. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

Not tested with current code