### PR TITLE
Fixes nor compsets

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1436,7 +1436,6 @@ contains
                 bc_out(s)%z0m_pa(ifp)    = EDPftvarcon_inst%z0mr(1) * bc_out(s)%htop_pa(ifp)
                 bc_out(s)%displa_pa(ifp) = EDPftvarcon_inst%displar(1) * bc_out(s)%htop_pa(ifp)
                 bc_out(s)%dleaf_pa(ifp)  = EDPftvarcon_inst%dleaf(1)
-                bc_out(s)%nocomp_MEGAN_pft_label_pa(ifp) = 1
              endif
              ! -----------------------------------------------------------------------------
 
@@ -1462,11 +1461,6 @@ contains
 
              bc_out(s)%nocomp_pft_label_pa(ifp) = currentPatch%nocomp_pft_label
 
-             if(currentPatch%nocomp_pft_label.gt.0)then
-                bc_out(s)%nocomp_MEGAN_pft_label_pa(ifp) = EDPftvarcon_inst%voc_pftindex(currentPatch%nocomp_pft_label)
-             else
-                bc_out(s)%nocomp_MEGAN_pft_label_pa(ifp) = 1 ! dummy for bare ground. 
-             endif
 
              ! Calculate area indices for output boundary to HLM
              ! It is assumed that cpatch%canopy_area_profile and cpat%xai_profiles

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -805,7 +805,7 @@ contains
     real(r8) :: sapw_c           ! sapwood carbon [kg]
     real(r8) :: store_c          ! storage carbon [kg]
     real(r8) :: struct_c         ! structure carbon [kg]
-    integer  :: min_canopy_layer
+    integer  :: min_occupied_clayer ! find the lowest layer with cohorts. 
     integer  :: layer_shift
     logical  :: has_veg_cohort
 
@@ -907,23 +907,26 @@ contains
 
           enddo ! ends 'do while(associated(currentCohort))
 
-           ! Enforce canopy-layer contiguity: if cohorts exist but layer 1 has no area,
+           ! Find out the minimum canopy layer than contains cohorts with c_area > nearzero
+           ! If cohorts exist in lower layers, but layer 1 has no area,
            ! shift all occupied layers upward so the minimum occupied layer is 1.
            if (currentPatch%total_canopy_area <= nearzero) then
-              min_canopy_layer = nclmax + 1
+              min_occupied_clayer = nclmax + 1 !set this to a high number and work upwards. 
               has_veg_cohort = .false.
               currentCohort => currentPatch%shortest
               do while(associated(currentCohort))
                  if (currentCohort%c_area > nearzero) then
                     has_veg_cohort = .true.
-                    min_canopy_layer = min(min_canopy_layer,currentCohort%canopy_layer)
+                    min_occupied_clayer = min(min_occupied_clayer,currentCohort%canopy_layer) !which is the lowest canopy lauyer with cohorts? 
                  end if
                  currentCohort => currentCohort%taller
               end do
 
-              if (has_veg_cohort .and. min_canopy_layer > 1) then
-                 layer_shift = min_canopy_layer - 1
+              ! Do we have any cohorts, and is the minimum layer for these cohorts lower than the 'canopy' (i.e. do we only have 'understorey' cohorts?? 
+              if (has_veg_cohort .and. min_occupied_clayer > 1) then
+                 layer_shift = min_occupied_clayer - 1
 
+                 ! If so, then shift all those cohorts up by (at least) one canopy layer, while retaiing the clayer structure of these cohorts. 
                  currentCohort => currentPatch%shortest
                  do while(associated(currentCohort))
                     currentCohort%canopy_layer = max(1,currentCohort%canopy_layer-layer_shift)
@@ -932,6 +935,7 @@ contains
 
                  currentPatch%NCL_p = NumCanopyLayers(currentPatch)
 
+                 ! in light of this change, recalculate the total canopy area. 
                  currentPatch%total_canopy_area = 0.0_r8
                  currentPatch%total_tree_area   = 0.0_r8
                  currentCohort => currentPatch%shortest

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1712,68 +1712,37 @@ contains
    type(fates_cohort_type), pointer :: currentCohort
    integer  :: cl                                  ! Canopy layer index
    integer  :: ft                                  ! Plant functional type index
-    real(r8) :: layer_area
-    real(r8) :: lai_norm_area
-    real(r8) :: areacanopies
-    
-    ! Calculate LAI of layers above.  Because it is possible for some understory cohorts
-    ! to be taller than cohorts in the top canopy layer, we must iterate through the
-    ! patch by canopy layer first.  Given that canopy_layer_tlai is a patch level variable
-    ! we could iterate through each cohort in any direction as long as we go down through
-    ! the canopy layers.
-    canopyloop: do cl = 1,nclmax
+   
+   ! Calculate LAI of layers above.  Because it is possible for some understory cohorts
+   ! to be taller than cohorts in the top canopy layer, we must iterate through the 
+   ! patch by canopy layer first.  Given that canopy_layer_tlai is a patch level variable
+   ! we could iterate through each cohort in any direction as long as we go down through
+   ! the canopy layers.
 
-       ! Determine the area represented by this canopy layer.
-       layer_area = 0.0_r8
-       currentCohort => currentPatch%tallest
-       do while(associated(currentCohort))
-          if (currentCohort%canopy_layer .eq. cl) then
-             layer_area = layer_area + currentCohort%c_area
-          end if
-          currentCohort => currentCohort%shorter
-       end do
+   canopyloop: do cl = 1,nclmax
+      currentCohort => currentPatch%tallest
+      cohortloop: do while(associated(currentCohort))
 
-       ! Use layer 1 canopy area when available, otherwise use this layer's own area.
-       ! If understory area exceeds canopy area, normalize by the larger footprint.
-       lai_norm_area = max(currentPatch%total_canopy_area, layer_area)
+         ! Only update the current cohort tree lai if lai of the above layers have been calculated
+         if (currentCohort%canopy_layer .eq. cl) then
+            
+            ft     = currentCohort%pft
+            ! Update the cohort level lai and related variables
+            call UpdateCohortLAI(currentCohort,currentPatch%canopy_layer_tlai,  &
+                 currentPatch%total_canopy_area)
+            
+            ! Update the number of number of vegetation layers
+            currentPatch%nleaf(cl,ft) = max(currentPatch%nleaf(cl,ft),currentCohort%NV)
 
-       areacanopies = 0.0_r8
-       currentCohort => currentPatch%tallest
-       cohortloop: do while(associated(currentCohort))
+            ! Update the patch canopy layer tlai (LAI per canopy area)
+            currentPatch%canopy_layer_tlai(cl) = currentPatch%canopy_layer_tlai(cl) +  &
+                 currentCohort%treelai *currentCohort%c_area/currentPatch%total_canopy_area
+            
+         end if
+         currentCohort => currentCohort%shorter
 
-          ft = currentCohort%pft
-          areacanopies = areacanopies + currentCohort%c_area
-          if(areacanopies .gt. nearzero .and. currentPatch%total_canopy_area .lt. nearzero) then
-             write(*,*) 'canopy is nearzero but areacanopies is not',currentPatch%total_canopy_area,currentPatch%area,currentPatch%nocomp_pft_label
-             write(*,*) 'cl,ft,carea,areacanopies',cl,ft,currentCohort%c_area, areacanopies
-          endif
-
-          ! Only update the current cohort tree lai if lai of the above layers have been calculated
-          if (currentCohort%canopy_layer .eq. cl) then
-
-             if(currentPatch%total_canopy_area.lt.nearzero)then
-                write(*,*) 'totcanopyarea > nearzero', cl, currentPatch%total_canopy_area
-                write(*,*) 'carea', ft, currentCohort%c_area,currentCohort%n,currentPatch%canopy_layer_tlai
-             endif
-
-             ! Update the cohort level lai and related variables
-             call UpdateCohortLAI(currentCohort,currentPatch%canopy_layer_tlai,  &
-                  lai_norm_area)
-
-             ! Update the number of number of vegetation layers
-             currentPatch%nleaf(cl,ft) = max(currentPatch%nleaf(cl,ft),currentCohort%NV)
-
-             ! Update the patch canopy layer tlai (LAI per effective canopy area)
-             if (lai_norm_area > nearzero) then
-                currentPatch%canopy_layer_tlai(cl) = currentPatch%canopy_layer_tlai(cl) +  &
-                     currentCohort%treelai *currentCohort%c_area/lai_norm_area
-             end if
-
-          end if
-          currentCohort => currentCohort%shorter
-
-       end do cohortloop
-    end do canopyloop
+      end do cohortloop
+   end do canopyloop
 
   end subroutine UpdatePatchLAI
   ! ===============================================================================================

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -805,6 +805,9 @@ contains
     real(r8) :: sapw_c           ! sapwood carbon [kg]
     real(r8) :: store_c          ! storage carbon [kg]
     real(r8) :: struct_c         ! structure carbon [kg]
+    integer  :: min_canopy_layer
+    integer  :: layer_shift
+    logical  :: has_veg_cohort
 
     !----------------------------------------------------------------------
 
@@ -903,6 +906,46 @@ contains
              currentCohort => currentCohort%taller
 
           enddo ! ends 'do while(associated(currentCohort))
+
+           ! Enforce canopy-layer contiguity: if cohorts exist but layer 1 has no area,
+           ! shift all occupied layers upward so the minimum occupied layer is 1.
+           if (currentPatch%total_canopy_area <= nearzero) then
+              min_canopy_layer = nclmax + 1
+              has_veg_cohort = .false.
+              currentCohort => currentPatch%shortest
+              do while(associated(currentCohort))
+                 if (currentCohort%c_area > nearzero) then
+                    has_veg_cohort = .true.
+                    min_canopy_layer = min(min_canopy_layer,currentCohort%canopy_layer)
+                 end if
+                 currentCohort => currentCohort%taller
+              end do
+
+              if (has_veg_cohort .and. min_canopy_layer > 1) then
+                 layer_shift = min_canopy_layer - 1
+
+                 currentCohort => currentPatch%shortest
+                 do while(associated(currentCohort))
+                    currentCohort%canopy_layer = max(1,currentCohort%canopy_layer-layer_shift)
+                    currentCohort => currentCohort%taller
+                 end do
+
+                 currentPatch%NCL_p = NumCanopyLayers(currentPatch)
+
+                 currentPatch%total_canopy_area = 0.0_r8
+                 currentPatch%total_tree_area   = 0.0_r8
+                 currentCohort => currentPatch%shortest
+                 do while(associated(currentCohort))
+                    if(currentCohort%canopy_layer==1)then
+                       currentPatch%total_canopy_area = currentPatch%total_canopy_area + currentCohort%c_area
+                       if( prt_params%woody(currentCohort%pft) == itrue)then
+                          currentPatch%total_tree_area = currentPatch%total_tree_area + currentCohort%c_area
+                       endif
+                    endif
+                    currentCohort => currentCohort%taller
+                 enddo
+              end if
+           end if
 
           if ( currentPatch%total_canopy_area>currentPatch%area ) then
              if ( currentPatch%total_canopy_area-currentPatch%area > 0.001_r8 ) then
@@ -1669,37 +1712,68 @@ contains
    type(fates_cohort_type), pointer :: currentCohort
    integer  :: cl                                  ! Canopy layer index
    integer  :: ft                                  ! Plant functional type index
-   
-   ! Calculate LAI of layers above.  Because it is possible for some understory cohorts
-   ! to be taller than cohorts in the top canopy layer, we must iterate through the 
-   ! patch by canopy layer first.  Given that canopy_layer_tlai is a patch level variable
-   ! we could iterate through each cohort in any direction as long as we go down through
-   ! the canopy layers.
+    real(r8) :: layer_area
+    real(r8) :: lai_norm_area
+    real(r8) :: areacanopies
+    
+    ! Calculate LAI of layers above.  Because it is possible for some understory cohorts
+    ! to be taller than cohorts in the top canopy layer, we must iterate through the
+    ! patch by canopy layer first.  Given that canopy_layer_tlai is a patch level variable
+    ! we could iterate through each cohort in any direction as long as we go down through
+    ! the canopy layers.
+    canopyloop: do cl = 1,nclmax
 
-   canopyloop: do cl = 1,nclmax
-      currentCohort => currentPatch%tallest
-      cohortloop: do while(associated(currentCohort))
+       ! Determine the area represented by this canopy layer.
+       layer_area = 0.0_r8
+       currentCohort => currentPatch%tallest
+       do while(associated(currentCohort))
+          if (currentCohort%canopy_layer .eq. cl) then
+             layer_area = layer_area + currentCohort%c_area
+          end if
+          currentCohort => currentCohort%shorter
+       end do
 
-         ! Only update the current cohort tree lai if lai of the above layers have been calculated
-         if (currentCohort%canopy_layer .eq. cl) then
-            
-            ft     = currentCohort%pft
-            ! Update the cohort level lai and related variables
-            call UpdateCohortLAI(currentCohort,currentPatch%canopy_layer_tlai,  &
-                 currentPatch%total_canopy_area)
-            
-            ! Update the number of number of vegetation layers
-            currentPatch%nleaf(cl,ft) = max(currentPatch%nleaf(cl,ft),currentCohort%NV)
+       ! Use layer 1 canopy area when available, otherwise use this layer's own area.
+       ! If understory area exceeds canopy area, normalize by the larger footprint.
+       lai_norm_area = max(currentPatch%total_canopy_area, layer_area)
 
-            ! Update the patch canopy layer tlai (LAI per canopy area)
-            currentPatch%canopy_layer_tlai(cl) = currentPatch%canopy_layer_tlai(cl) +  &
-                 currentCohort%treelai *currentCohort%c_area/currentPatch%total_canopy_area
-            
-         end if
-         currentCohort => currentCohort%shorter
+       areacanopies = 0.0_r8
+       currentCohort => currentPatch%tallest
+       cohortloop: do while(associated(currentCohort))
 
-      end do cohortloop
-   end do canopyloop
+          ft = currentCohort%pft
+          areacanopies = areacanopies + currentCohort%c_area
+          if(areacanopies .gt. nearzero .and. currentPatch%total_canopy_area .lt. nearzero) then
+             write(*,*) 'canopy is nearzero but areacanopies is not',currentPatch%total_canopy_area,currentPatch%area,currentPatch%nocomp_pft_label
+             write(*,*) 'cl,ft,carea,areacanopies',cl,ft,currentCohort%c_area, areacanopies
+          endif
+
+          ! Only update the current cohort tree lai if lai of the above layers have been calculated
+          if (currentCohort%canopy_layer .eq. cl) then
+
+             if(currentPatch%total_canopy_area.lt.nearzero)then
+                write(*,*) 'totcanopyarea > nearzero', cl, currentPatch%total_canopy_area
+                write(*,*) 'carea', ft, currentCohort%c_area,currentCohort%n,currentPatch%canopy_layer_tlai
+             endif
+
+             ! Update the cohort level lai and related variables
+             call UpdateCohortLAI(currentCohort,currentPatch%canopy_layer_tlai,  &
+                  lai_norm_area)
+
+             ! Update the number of number of vegetation layers
+             currentPatch%nleaf(cl,ft) = max(currentPatch%nleaf(cl,ft),currentCohort%NV)
+
+             ! Update the patch canopy layer tlai (LAI per effective canopy area)
+             if (lai_norm_area > nearzero) then
+                currentPatch%canopy_layer_tlai(cl) = currentPatch%canopy_layer_tlai(cl) +  &
+                     currentCohort%treelai *currentCohort%c_area/lai_norm_area
+             end if
+
+          end if
+          currentCohort => currentCohort%shorter
+
+       end do cohortloop
+    end do canopyloop
 
   end subroutine UpdatePatchLAI
   ! ===============================================================================================

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2536,8 +2536,29 @@ contains
       real(r8)                          :: seedling_layer_smp ! soil matric potential at seedling rooting depth [mm H2O suction]
       integer, parameter                :: recruitstatus = 1  ! whether the newly created cohorts are recruited or initialized
       integer                           :: ilayer_seedling_root ! the soil layer at seedling rooting depth
+      integer                           :: recruit_clayer      ! layer assigned to newly recruited cohorts
       logical                           :: use_this_pft         ! logical flag for whether or not to allow a given PFT to recruit
+      real(r8)                          :: layer1_canopy_area   ! computed total crown area currently in canopy layer 1
+      type(fates_cohort_type), pointer  :: currentCohort
       !---------------------------------------------------------------------------
+      ! Minimal canopy-layer safeguard for recruitment:
+      ! if no crown area exists in layer 1, force new recruits into layer 1.
+      layer1_canopy_area = 0._r8
+      currentCohort => currentPatch%tallest
+      do while (associated(currentCohort))
+         if (currentCohort%canopy_layer == 1) then
+            call carea_allom(currentCohort%dbh,currentCohort%n,currentSite%spread, &
+                 currentCohort%pft,currentCohort%crowndamage,currentCohort%c_area)
+            layer1_canopy_area = layer1_canopy_area + currentCohort%c_area
+         end if
+         currentCohort => currentCohort%shorter
+      end do
+
+      recruit_clayer = currentPatch%NCL_p
+      if (recruit_clayer > 1 .and. layer1_canopy_area <= nearzero) then
+         recruit_clayer = 1
+      end if
+
 
       do ft = 1, numpft
 
@@ -2568,7 +2589,7 @@ contains
             height             = EDPftvarcon_inst%hgt_min(ft)
             stem_drop_fraction = prt_params%phen_stem_drop_fraction(ft)
             fnrt_drop_fraction = prt_params%phen_fnrt_drop_fraction(ft)
-            l2fr               = currentSite%rec_l2fr(ft, currentPatch%NCL_p)
+            l2fr               = currentSite%rec_l2fr(ft, recruit_clayer)
             crowndamage        = 1 ! new recruits are undamaged
 
             ! calculate DBH from initial height
@@ -2801,7 +2822,7 @@ contains
                call create_cohort(currentSite, currentPatch, ft, cohort_n,     &
                   height, 0.0_r8, dbh, prt, efleaf_coh, effnrt_coh, efstem_coh,  &
                   leaf_status, recruitstatus, init_recruit_trim, 0.0_r8,       &
-                  currentPatch%NCL_p, crowndamage, currentSite%spread, bc_in)
+                  recruit_clayer, crowndamage, currentSite%spread, bc_in)
 
                ! Note that if hydraulics is on, the number of cohorts may have
                ! changed due to hydraulic constraints.

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2536,29 +2536,8 @@ contains
       real(r8)                          :: seedling_layer_smp ! soil matric potential at seedling rooting depth [mm H2O suction]
       integer, parameter                :: recruitstatus = 1  ! whether the newly created cohorts are recruited or initialized
       integer                           :: ilayer_seedling_root ! the soil layer at seedling rooting depth
-      integer                           :: recruit_clayer      ! layer assigned to newly recruited cohorts
       logical                           :: use_this_pft         ! logical flag for whether or not to allow a given PFT to recruit
-      real(r8)                          :: layer1_canopy_area   ! computed total crown area currently in canopy layer 1
-      type(fates_cohort_type), pointer  :: currentCohort
       !---------------------------------------------------------------------------
-      ! Minimal canopy-layer safeguard for recruitment:
-      ! if no crown area exists in layer 1, force new recruits into layer 1.
-      layer1_canopy_area = 0._r8
-      currentCohort => currentPatch%tallest
-      do while (associated(currentCohort))
-         if (currentCohort%canopy_layer == 1) then
-            call carea_allom(currentCohort%dbh,currentCohort%n,currentSite%spread, &
-                 currentCohort%pft,currentCohort%crowndamage,currentCohort%c_area)
-            layer1_canopy_area = layer1_canopy_area + currentCohort%c_area
-         end if
-         currentCohort => currentCohort%shorter
-      end do
-
-      recruit_clayer = currentPatch%NCL_p
-      if (recruit_clayer > 1 .and. layer1_canopy_area <= nearzero) then
-         recruit_clayer = 1
-      end if
-
 
       do ft = 1, numpft
 
@@ -2589,7 +2568,7 @@ contains
             height             = EDPftvarcon_inst%hgt_min(ft)
             stem_drop_fraction = prt_params%phen_stem_drop_fraction(ft)
             fnrt_drop_fraction = prt_params%phen_fnrt_drop_fraction(ft)
-            l2fr               = currentSite%rec_l2fr(ft, recruit_clayer)
+            l2fr               = currentSite%rec_l2fr(ft, currentPatch%NCL_p)
             crowndamage        = 1 ! new recruits are undamaged
 
             ! calculate DBH from initial height
@@ -2822,7 +2801,7 @@ contains
                call create_cohort(currentSite, currentPatch, ft, cohort_n,     &
                   height, 0.0_r8, dbh, prt, efleaf_coh, effnrt_coh, efstem_coh,  &
                   leaf_status, recruitstatus, init_recruit_trim, 0.0_r8,       &
-                  recruit_clayer, crowndamage, currentSite%spread, bc_in)
+                  currentPatch%NCL_p, crowndamage, currentSite%spread, bc_in)
 
                ! Note that if hydraulics is on, the number of cohorts may have
                ! changed due to hydraulic constraints.

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -307,7 +307,6 @@ module FatesHistoryInterfaceMod
   integer :: ih_seeds_in_local_si       ! carbon only
   integer :: ih_ungerm_seed_bank_si     ! carbon only
   integer :: ih_seedling_pool_si        ! carbon only
-  integer :: ih_phen_day_si                ! phenology day
   integer :: ih_ba_weighted_height_si
   integer :: ih_ca_weighted_height_si
   integer :: ih_patch_weighted_95thpctile_height_si
@@ -2490,7 +2489,6 @@ contains
          hio_seed_bank_si        => this%hvars(ih_seed_bank_si)%r81d, &
          hio_ungerm_seed_bank_si => this%hvars(ih_ungerm_seed_bank_si)%r81d, &
          hio_seedling_pool_si    => this%hvars(ih_seedling_pool_si)%r81d, &
-         hio_phen_day_si         => this%hvars(ih_phen_day_si)%r81d, &
          hio_seeds_in_si         => this%hvars(ih_seeds_in_si)%r81d, &
          hio_seeds_in_local_si   => this%hvars(ih_seeds_in_local_si)%r81d, &
          hio_bdead_si            => this%hvars(ih_bdead_si)%r81d, &
@@ -2596,7 +2594,6 @@ contains
          ! Model days elapsed since leaf on/off for cold-deciduous
          hio_cleafoff_si(io_si) = real(sites(s)%phen_model_date - sites(s)%cleafoffdate,r8)
          hio_cleafon_si(io_si)  = real(sites(s)%phen_model_date - sites(s)%cleafondate,r8)
-         hio_phen_day_si(io_si) = real(sites(s)%phen_model_date,r8)
 
          ! site-level fire variables:
 
@@ -3385,6 +3382,7 @@ contains
              hio_secondary_agb_si_agesinceanthro  => this%hvars(ih_secondary_agb_si_agesinceanthro)%r82d, &
              hio_sapwood_area_scpf              => this%hvars(ih_sapwood_area_scpf)%r82d)
 
+          model_day_int = nint(hlm_model_day)
 
           ! ---------------------------------------------------------------------------------
           ! Loop through the FATES scale hierarchy and fill the history IO arrays
@@ -3394,7 +3392,7 @@ contains
           siteloop: do s = 1,nsites
 
              io_si  = sites(s)%h_gid
-             model_day_int = sites(s)%phen_model_date
+
              ! C13 will not get b4b restarts on the first day because
              ! there is no mechanism to remember the previous day's values
              ! through a restart. This should be added with the next refactor
@@ -5478,7 +5476,7 @@ contains
 
          cpatch => sites(s)%oldest_patch
          do while(associated(cpatch))
-            if (cpatch%total_canopy_area .gt. rsnbl_math_prec ) then
+            if (cpatch%total_canopy_area .gt. rsnbl_math_prec) then
                ! for TVEG, since it is only defined on vegetated area of vegetated patches, normalize by the total vegetated area
                hio_tveg_si_landuse(io_si,cpatch%land_use_label) = hio_tveg_si_landuse(io_si,cpatch%land_use_label) + &
                     bc_in(s)%t_veg_pa(cpatch%patchno) * cpatch%total_canopy_area/canopy_area_bylanduse(cpatch%land_use_label)
@@ -6871,12 +6869,6 @@ contains
             use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',     &
             upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
             index = ih_seedling_pool_si)
-
-       call this%set_history_var(vname='FATES_PHEN_DAY', units='days',         &
-            long='phenology day',     &
-            use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',     &
-            upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
-            index = ih_phen_day_si)
 
        call this%set_history_var(vname='FATES_SEEDS_IN', units='kg m-2 s-1',      &
             long='seed production rate in kg carbon per m2 second',               &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -9233,25 +9233,25 @@ contains
 
           call this%set_history_var(vname='FATES_SWABS_LU', units='W m-2', &
                long='fates absorbed shortwave radiation by land use type', &
-               use_default='active', &
+               use_default='inactive', &
                avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
                ivar=ivar, initialize=initialize_variables, index = ih_sw_abs_si_landuse )
 
           call this%set_history_var(vname='FATES_NETLW_LU', units='W m-2', &
                long='fates net longwave flux by land use type', &
-               use_default='active', &
+               use_default='inactive', &
                avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
                ivar=ivar, initialize=initialize_variables, index = ih_lw_net_si_landuse )
 
           call this%set_history_var(vname='FATES_SHFLUX_LU', units='W m-2', &
                long='fates sensible heat flux by land use type', &
-               use_default='active', &
+               use_default='inactive', &
                avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
                ivar=ivar, initialize=initialize_variables, index = ih_shflux_si_landuse )
 
           call this%set_history_var(vname='FATES_LHFLUX_LU', units='W m-2', &
                long='fates latent heat flux by land use type', &
-               use_default='active', &
+               use_default='inactive', &
                avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
                ivar=ivar, initialize=initialize_variables, index = ih_lhflux_si_landuse )
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -307,6 +307,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_seeds_in_local_si       ! carbon only
   integer :: ih_ungerm_seed_bank_si     ! carbon only
   integer :: ih_seedling_pool_si        ! carbon only
+  integer :: ih_phen_day_si                ! phenology day
   integer :: ih_ba_weighted_height_si
   integer :: ih_ca_weighted_height_si
   integer :: ih_patch_weighted_95thpctile_height_si
@@ -2489,6 +2490,7 @@ contains
          hio_seed_bank_si        => this%hvars(ih_seed_bank_si)%r81d, &
          hio_ungerm_seed_bank_si => this%hvars(ih_ungerm_seed_bank_si)%r81d, &
          hio_seedling_pool_si    => this%hvars(ih_seedling_pool_si)%r81d, &
+         hio_phen_day_si         => this%hvars(ih_phen_day_si)%r81d, &
          hio_seeds_in_si         => this%hvars(ih_seeds_in_si)%r81d, &
          hio_seeds_in_local_si   => this%hvars(ih_seeds_in_local_si)%r81d, &
          hio_bdead_si            => this%hvars(ih_bdead_si)%r81d, &
@@ -2594,6 +2596,7 @@ contains
          ! Model days elapsed since leaf on/off for cold-deciduous
          hio_cleafoff_si(io_si) = real(sites(s)%phen_model_date - sites(s)%cleafoffdate,r8)
          hio_cleafon_si(io_si)  = real(sites(s)%phen_model_date - sites(s)%cleafondate,r8)
+         hio_phen_day_si(io_si) = real(sites(s)%phen_model_date,r8)
 
          ! site-level fire variables:
 
@@ -3382,7 +3385,6 @@ contains
              hio_secondary_agb_si_agesinceanthro  => this%hvars(ih_secondary_agb_si_agesinceanthro)%r82d, &
              hio_sapwood_area_scpf              => this%hvars(ih_sapwood_area_scpf)%r82d)
 
-          model_day_int = nint(hlm_model_day)
 
           ! ---------------------------------------------------------------------------------
           ! Loop through the FATES scale hierarchy and fill the history IO arrays
@@ -3392,7 +3394,7 @@ contains
           siteloop: do s = 1,nsites
 
              io_si  = sites(s)%h_gid
-
+             model_day_int = sites(s)%phen_model_date
              ! C13 will not get b4b restarts on the first day because
              ! there is no mechanism to remember the previous day's values
              ! through a restart. This should be added with the next refactor
@@ -5476,7 +5478,7 @@ contains
 
          cpatch => sites(s)%oldest_patch
          do while(associated(cpatch))
-            if (cpatch%total_canopy_area .gt. rsnbl_math_prec) then
+            if (cpatch%total_canopy_area .gt. rsnbl_math_prec ) then
                ! for TVEG, since it is only defined on vegetated area of vegetated patches, normalize by the total vegetated area
                hio_tveg_si_landuse(io_si,cpatch%land_use_label) = hio_tveg_si_landuse(io_si,cpatch%land_use_label) + &
                     bc_in(s)%t_veg_pa(cpatch%patchno) * cpatch%total_canopy_area/canopy_area_bylanduse(cpatch%land_use_label)
@@ -6869,6 +6871,12 @@ contains
             use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',     &
             upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
             index = ih_seedling_pool_si)
+
+       call this%set_history_var(vname='FATES_PHEN_DAY', units='days',         &
+            long='phenology day',     &
+            use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',     &
+            upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
+            index = ih_phen_day_si)
 
        call this%set_history_var(vname='FATES_SEEDS_IN', units='kg m-2 s-1',      &
             long='seed production rate in kg carbon per m2 second',               &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -3382,7 +3382,6 @@ contains
              hio_secondary_agb_si_agesinceanthro  => this%hvars(ih_secondary_agb_si_agesinceanthro)%r82d, &
              hio_sapwood_area_scpf              => this%hvars(ih_sapwood_area_scpf)%r82d)
 
-          model_day_int = nint(hlm_model_day)
 
           ! ---------------------------------------------------------------------------------
           ! Loop through the FATES scale hierarchy and fill the history IO arrays
@@ -3392,7 +3391,8 @@ contains
           siteloop: do s = 1,nsites
 
              io_si  = sites(s)%h_gid
-
+             ! make this consistent with what is in the phenology
+             model_day_int = sites(s)%phen_model_date
              ! C13 will not get b4b restarts on the first day because
              ! there is no mechanism to remember the previous day's values
              ! through a restart. This should be added with the next refactor

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -249,6 +249,10 @@ contains
     allocate(bc_pconst%eca_alpha_ptase(numpft))
     allocate(bc_pconst%eca_lambda_ptase(numpft))
     allocate(bc_pconst%j_uptake(nlevdecomp))
+    allocate(bc_pconst%wesley_veg_index(numpft))
+    allocate(bc_pconst%wesley_sum_thresh(numpft))
+    allocate(bc_pconst%wesley_aut_thresh(numpft))
+    allocate(bc_pconst%voc_pftindex(numpft))
     
     return
   end subroutine allocate_bcpconst
@@ -273,6 +277,11 @@ contains
     bc_pconst%eca_alpha_ptase(1:numpft)  = EDPftvarcon_inst%eca_alpha_ptase(1:numpft) 
     bc_pconst%eca_lambda_ptase(1:numpft) = EDPftvarcon_inst%eca_lambda_ptase(1:numpft)
     bc_pconst%eca_plant_escalar          = eca_plant_escalar
+
+    bc_pconst%wesley_veg_index(1:numpft)  = EDPftvarcon_inst%wesley_veg_index(1:numpft)
+    bc_pconst%wesley_sum_thresh(1:numpft) = EDPftvarcon_inst%wesley_sum_thresh(1:numpft)
+    bc_pconst%wesley_aut_thresh(1:numpft) = EDPftvarcon_inst%wesley_aut_thresh(1:numpft)
+    bc_pconst%voc_pftindex(1:numpft)   = EDPftvarcon_inst%voc_pftindex(1:numpft)
     
     return
   end subroutine set_bcpconst
@@ -411,7 +420,6 @@ contains
     fates%bc_out(s)%z0m_pa(:)    = 0.0_r8
     fates%bc_out(s)%dleaf_pa(:)   = 0.0_r8
     fates%bc_out(s)%nocomp_pft_label_pa(:) = 0
-    fates%bc_out(s)%nocomp_MEGAN_pft_label_pa(:) = 0
     fates%bc_out(s)%canopy_fraction_pa(:) = 0.0_r8
     fates%bc_out(s)%frac_veg_nosno_alb_pa(:) = 0.0_r8
     
@@ -753,7 +761,6 @@ contains
       allocate(bc_out%frac_veg_nosno_alb_pa(maxpatch_total))
 
       allocate(bc_out%nocomp_pft_label_pa(maxpatch_total))
-      allocate(bc_out%nocomp_MEGAN_pft_label_pa(maxpatch_total))      
       allocate(bc_out%drydep_season_pa(maxpatch_total))
 
       ! Plant-Hydro BC's

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -784,7 +784,6 @@ module FatesInterfaceTypesMod
      integer, allocatable :: wesley_pft_label_pa(:) ! For dry deposition, each FATES PFT needs to correspond to a PFT from the 'wesley 1989' scheme 
      integer, allocatable :: drydep_season_pa(:) ! For dry deposition, we need to define the season index, from 1-5, for the purposes of detrmining the deposition velocity parameters. See drydep code for details of season indices. 
 
-     integer, allocatable :: nocomp_MEGAN_pft_label_pa(:) ! Index to map from FATES NOCOMP PFT identity into MEGAN PFT space. 
           
       ! FATES Hydraulics
 
@@ -862,6 +861,10 @@ module FatesInterfaceTypesMod
                                                 ! layers and the uptake layers
                                                 ! in FATES (is either incrementally
                                                 ! increasing, or all 1s)
+       integer, pointer :: wesley_veg_index(:)
+       integer, pointer :: wesley_sum_thresh(:)
+       integer, pointer :: wesley_aut_thresh(:)
+       integer, pointer :: voc_pftindex(:)
 
    end type bc_pconst_type
 

--- a/parameter_files/fates_params_noresm.json
+++ b/parameter_files/fates_params_noresm.json
@@ -688,7 +688,7 @@
       "dims": ["fates_pft"],
       "long_name": "Fraction of PFT killed during land use clearing to rangeland",
       "units": "fraction",
-      "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      "data":  [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     },
     "fates_landuse_harvest_pprod10":{
       "dtype": "float",


### PR DESCRIPTION
1. Make model_day consistent for memory variables between where they are calculated and outputed.
2. Remove _LU radiation variables.
3. Cohorts in wrong class fix.
4. Refactor parameter passing  for drydep and voc's.
5. Fix clearing mortality parameter.