### PR TITLE
Modify grass fire params to reduce burned area AND l2fr & root depth of EBTs to help Amazon LAI

### DIFF
--- a/parameter_files/fates_params_noresm.json
+++ b/parameter_files/fates_params_noresm.json
@@ -240,7 +240,7 @@
       "dims": ["fates_pft"],
       "long_name": "Fine root profile function, parameter b",
       "units": "unitless",
-      "data": [0.511, 2.0, 2.0, 1.0, 2.0, 2.0, 1.5, 1.5, 1.5, 1.5, 1.5, 2.29, 2.0, 2.0, 2.0]
+      "data": [0.3, 2.0, 2.0, 1.0, 2.0, 2.0, 1.5, 1.5, 1.5, 1.5, 1.5, 2.29, 2.0, 2.0, 2.0]
     },
     "fates_allom_fnrt_prof_mode":{
       "dtype": "integer",
@@ -282,7 +282,7 @@
       "dims": ["fates_pft"],
       "long_name": "Allocation parameter  fine root C per leaf C",
       "units": "gC/gC",
-      "data": [1.5, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.7, 0.75, 1.4, 1.3, 1.3, 2.3, 1.5]
+      "data": [1.0, 0.75, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.7, 0.75, 1.4, 1.3, 1.3, 2.3, 1.5]
     },
     "fates_allom_la_per_sa_int":{
       "dtype": "float",
@@ -1675,7 +1675,7 @@
       "dims": ["fates_litterclass"],
       "long_name": "maximum rate of litter and CWD transfer from non-decomposing class into decomposing class",
       "units": "yr-1",
-      "data": [0.52, 0.383, 0.383, 0.19, 3.0, 999.0]
+      "data": [0.52, 0.383, 0.383, 0.19, 2.0, 999.0]
     },
     "fates_litterclass_name":{
       "dtype": "string",

--- a/parameter_files/fates_params_noresm.json
+++ b/parameter_files/fates_params_noresm.json
@@ -1626,7 +1626,7 @@
       "dims": ["fates_litterclass"],
       "long_name": "fuel surface area to volume ratio",
       "units": "cm-1",
-      "data": [13.0, 3.58, 0.98, 0.2, 66.0, 66.0]
+      "data": [13.0, 3.58, 0.98, 0.2, 35.0, 35.0]
     },
     "fates_fire_low_moisture_Coeff":{
       "dtype": "float",
@@ -1675,7 +1675,7 @@
       "dims": ["fates_litterclass"],
       "long_name": "maximum rate of litter and CWD transfer from non-decomposing class into decomposing class",
       "units": "yr-1",
-      "data": [0.52, 0.383, 0.383, 0.19, 1.0, 999.0]
+      "data": [0.52, 0.383, 0.383, 0.19, 3.0, 999.0]
     },
     "fates_litterclass_name":{
       "dtype": "string",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I located a change that reduces the existing very high bias in grass fires and is consistant with literature on this topic. There are two changes: 

1. We decrease the surface area to volume of grass fuels from 66 to 35 cm2 cm-3. 
2. We increase the fragmentation rate of grasst fuels from 1 to 3. 

The former is based on the fact the the value of 66 is towards the upper end of understood values for grass fuels (49-72 cm-1), as well as the flaw in the SPITFIRE weighting scheme discussed in 
https://gmd.copernicus.org/articles/18/2021/2025/gmd-18-2021-2025.pdf
which illustrates that we are not properly weighting the fuel types by surface area. In lieu of actually making this structural correction, we adopt a lower value  for this parameter. Lasslop et al. (2014) reduced this value to 13 to account for other structural issues in the model (lack of surface heteroeneity and windspeed responses) so this value is a compromise. 

We also increase the turnover time for fragmentation pathways for grass in semi arid systems that are not subject to the moisture response functions of the microbial pathway.  These include physical collapse, macroinvertebrate consumption (termites) and photodegradation. All of which in theory should speed up the process of conversion to soil organic matter from standing litter. 

Introducing this change hugely improves the model biases wrt burned area. 

here are burn area bias maps for simulations before 
<img width="3000" height="1000" alt="image" src="https://github.com/user-attachments/assets/05f59352-4380-4d1c-90cd-2f0ace7514da" /> 

and after this change. 
<img width="3000" height="1000" alt="image" src="https://github.com/user-attachments/assets/604c3b92-af3e-4d54-b045-3ba82097d20e" />


(note that there are some minor modifications to grazing in the control here, but nothing that affects the burned area very sinificantly. )

This is a change that affects grassland areas primarily. I will try and make a clean comparison plot with the default code soon. But this is such a big improvement that I wanted to get it in the system asap, given the short timeline 








### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Description of generative AI usage (as necessary)
<!--- Please briefly describe usage of generative AI, such as  -->
<!--- platform, AI model, workflow, testing, etc. -->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary
- [ ] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

