### PR TITLE
Attempted fix to  have consistent gating of radiation scheme

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -80,6 +80,7 @@ module EDPatchDynamicsMod
   use FatesConstantsMod    , only : days_per_sec
   use FatesConstantsMod    , only : years_per_day
   use FatesConstantsMod    , only : nearzero
+  use FatesConstantsMod    , only : min_disturb_frac
   use FatesConstantsMod    , only : primaryland, secondaryland, pastureland, rangeland, cropland
   use FatesConstantsMod    , only : nocomp_bareground_land
   use FatesConstantsMod    , only : n_landuse_cats
@@ -657,8 +658,11 @@ contains
                             disturbance_rate = 1.0_r8
                          end if
 
-                         ! Only create new patches that have non-negligible amount of land
-                         if((currentPatch%area*disturbance_rate) > nearzero ) then
+                         ! Only create new patches that have non-negligible amount of land.
+                         ! Use a relative gate (fraction of the donor patch that is disturbed)
+                         ! rather than an absolute one, so vanishingly small disturbance areas
+                         ! are left in the donor patch instead of spawning a degenerate patch.
+                         if(disturbance_rate > min_disturb_frac ) then
 
                             site_areadis = site_areadis + currentPatch%area * disturbance_rate
 
@@ -674,7 +678,7 @@ contains
                 enddo patchloop_areadis! end loop over patches. sum area disturbed for all patches.
 
                 ! It is possible that no disturbance area was generated
-                if ( site_areadis > nearzero) then
+                if ( site_areadis > min_disturb_frac*area_site) then
 
                    age = 0.0_r8
 
@@ -728,7 +732,7 @@ contains
                          ! patch_site_areadis is the absolute amount of the patch's area that is disturbed and donated
                          patch_site_areadis = currentPatch%area * disturbance_rate
                          
-                         areadis_gt_zero_if: if ( patch_site_areadis > nearzero ) then
+                         areadis_gt_zero_if: if ( disturbance_rate > min_disturb_frac ) then
 
                             if(.not.associated(newPatch))then
                                write(fates_log(),*) 'Patch spawning has attempted to point to'

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -206,6 +206,21 @@ integer, parameter, public :: isemi_stress_decid = 4 ! Flag that indicates that 
   ! precisions are preventing perfect zero in comparison
   real(fates_r8), parameter, public :: nearzero = 1.0e-30_fates_r8
 
+  ! Minimum canopy-area fraction (patch total canopy area / patch area) for a
+  ! patch to be considered to have enough vegetation to warrant a radiation
+  ! solve. This is a *relative* admission gate, consistent with the Norman
+  ! solver's canopy-area test, and replaces absolute "nearzero" gates that
+  ! admitted degenerate, vanishingly small patches into the two-stream solver,
+  ! where the per-element area normalization (division by total canopy area)
+  ! becomes ill-conditioned and trips the conservation checks.
+  real(fates_r8), parameter, public :: rad_min_canopy_frac = 1.0e-9_fates_r8
+
+  ! Minimum disturbance fraction (disturbed area / donor patch area) required to
+  ! spawn a new disturbance patch. Below this *relative* threshold the disturbed
+  ! area is left in the donor patch rather than creating a degenerate tiny patch
+  ! that would later stress area-conservation and radiation checks.
+  real(fates_r8), parameter, public :: min_disturb_frac = 1.0e-9_fates_r8
+
   ! Unit conversion constants:
 
   ! Conversion factor umols of Carbon -> kg of Carbon (1 mol = 12g)

--- a/radiation/FatesTwoStreamUtilsMod.F90
+++ b/radiation/FatesTwoStreamUtilsMod.F90
@@ -9,6 +9,7 @@ Module FatesTwoStreamUtilsMod
   use FatesConstantsMod     , only : ifalse
   use FatesConstantsMod     , only : itrue
   use FatesConstantsMod     , only : nearzero,nocomp_bareground
+  use FatesConstantsMod     , only : rad_min_canopy_frac
   use shr_log_mod           , only : errMsg => shr_log_errMsg
   use FatesGlobals          , only : fates_log
   use FatesGlobals          , only : endrun => fates_endrun
@@ -149,7 +150,7 @@ contains
          ! LAI and SAI to conserve area)
         
             
-         if(patch%total_canopy_area>nearzero)then
+         if(patch%total_canopy_area > rad_min_canopy_frac*patch%area)then
             canopy_frac(:) = 0._r8
             cohort => patch%tallest
             do while (associated(cohort))


### PR DESCRIPTION
Attempted fix to  have consistent gating of size of patches considered by the radiation scheme to avoid crashes with tiny patches

<!--- Provide a general summary of your changes in the Title above -->

Changing comparisons from absolute to relative and using a consistent larger relative size value to avoid having the radiation scheme considering tiny patches, dividing with other tiny numbers and causing issues 

### Description:

This seems to be a repeated issue in crashes, not sure I have a recent issue to put just now

### Collaborators:

@JessicaNeedham, @rosiealice @rgknox

### Expectation of Answer Changes:

Might be margianlly answerchanging for albedo of small patches

### Description of generative AI usage (as necessary)

After the analysis that eventually lead to #66 it seemed like a related problem of tiny patch creation being allowed and leading to TwoStream radiation errors which keep coming up seemed like a natural thing to enquire further about. I prompted Claude Opus 4.8 to continue the investigation in this direction and got the second report included here: 
https://github.com/NorESMhub/CTSM/issues/237

This issue is a prompted code change attempt at solving the core issue described there of too small patches being considered by the radiation code.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

